### PR TITLE
Rename --ignore-non-exist-features flag to --ignore-unknown-features

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ To install the current cargo-hack requires Rust 1.36 or later.
 
   Skip to perform on `publish = false` packages.
 
-* **`--ignore-non-exist-features`**
+* **`--ignore-unknown-features`**
 
   Skip passing `--features` to `cargo` if that feature does not exist.
 
   This is a workaround for an issue that `cargo` does not support for `--features` with workspace ([rust-lang/cargo#3620], [rust-lang/cargo#4106], [rust-lang/cargo#4463], [rust-lang/cargo#4753], [rust-lang/cargo#5015], [rust-lang/cargo#5364], [rust-lang/cargo#6195]).
+
+  This feature was formerly called `--ignore-unknown-features`, but has been renamed. The old name can be used as an alias, but is deprecated.
 
 `cargo-hack` changes the behavior of the following existing flags.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,7 @@ fn no_dev_deps(manifest: &Manifest, args: &Options) -> Result<()> {
 
 fn each_feature(manifest: &Manifest, args: &Options) -> Result<()> {
     let mut features = String::new();
-    if args.ignore_non_exist_features {
+    if args.ignore_unknown_features {
         let f: Vec<_> = args
             .features
             .iter()
@@ -199,7 +199,7 @@ fn each_feature(manifest: &Manifest, args: &Options) -> Result<()> {
                     // ignored
                     info!(
                         args.color,
-                        "skipped applying non-exist `{}` feature to {}",
+                        "skipped applying unknown `{}` feature to {}",
                         f,
                         manifest.package_name_verbose(args)
                     );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -247,6 +247,20 @@ fn test_exclude() {
 }
 
 #[test]
+fn test_ignore_unknown_features() {
+    let output = cargo_hack()
+        .args(&["hack", "check", "--ignore-unknown-features", "--features=f"])
+        .current_dir(test_dir("tests/fixtures/virtual"))
+        .output()
+        .unwrap();
+
+    output
+        .assert_success()
+        .assert_stderr_contains("skipped applying unknown `f` feature to member1")
+        .assert_stderr_contains("skipped applying unknown `f` feature to member2");
+}
+
+#[test]
 fn test_ignore_non_exist_features() {
     let output = cargo_hack()
         .args(&["hack", "check", "--ignore-non-exist-features", "--features=f"])
@@ -256,8 +270,9 @@ fn test_ignore_non_exist_features() {
 
     output
         .assert_success()
-        .assert_stderr_contains("skipped applying non-exist `f` feature to member1")
-        .assert_stderr_contains("skipped applying non-exist `f` feature to member2");
+        .assert_stderr_contains("'--ignore-non-exist-features' flag is deprecated, use '--ignore-unknown-features' flag instead")
+        .assert_stderr_contains("skipped applying unknown `f` feature to member1")
+        .assert_stderr_contains("skipped applying unknown `f` feature to member2");
 }
 
 #[test]


### PR DESCRIPTION
The old name can be used as an alias, but is deprecated.