### PR TITLE
Pass --target-dir option directly to cargo

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf, rc::Rc, str::FromStr};
+use std::{env, rc::Rc, str::FromStr};
 
 use anyhow::{format_err, Error, Result};
 use termcolor::ColorChoice;
@@ -26,9 +26,6 @@ OPTIONS:
                                     (this flag will not be propagated to cargo)
         --exclude <SPEC>...         Exclude packages from the check
                                     (this flag will not be propagated to cargo)
-        --target-dir <DIRECTORY>    Directory for all generated artifacts
-                                    (this flag will be passed to cargo after
-                                    normalizing the given path)
         --manifest-path <PATH>      Path to Cargo.toml
                                     (this flag will not be propagated to cargo)
         --features <FEATURES>...    Space-separated list of features to activate
@@ -71,8 +68,6 @@ pub(crate) struct Args {
 
     /// --manifest-path <PATH>
     pub(crate) manifest_path: Option<String>,
-    /// (canonicalized) --target-dir <DIRECTORY>
-    pub(crate) target_dir: Option<PathBuf>,
     /// --features <FEATURES>...
     pub(crate) features: Vec<String>,
 
@@ -153,7 +148,6 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<std::result::Resul
     let mut leading = Vec::new();
     let mut subcommand: Option<String> = None;
 
-    let mut target_dir = None;
     let mut manifest_path = None;
     let mut color = None;
 
@@ -253,13 +247,6 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<std::result::Resul
             }
 
             parse_arg1!(
-                target_dir,
-                false,
-                "--target-dir",
-                "--target-dir=",
-                "--target-dir <DIRECTORY>"
-            );
-            parse_arg1!(
                 manifest_path,
                 false,
                 "--manifest-path",
@@ -337,7 +324,6 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<std::result::Resul
         return Ok(Err(0));
     }
 
-    let target_dir = target_dir.map(fs::canonicalize).transpose()?;
     let verbose = leading.iter().any(|a| a == "--verbose" || a == "-v" || a == "-vv");
     if ignore_non_exist_features {
         warn!(
@@ -423,7 +409,6 @@ For more information try --help
 
         subcommand,
         manifest_path,
-        target_dir,
         package,
         exclude,
         features,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,11 +48,6 @@ fn try_main(coloring: &mut Option<Coloring>) -> Result<()> {
 fn exec_on_workspace(args: &Args, current_manifest: &Manifest, metadata: &Metadata) -> Result<()> {
     let mut line = ProcessBuilder::from_args(cargo_binary(), &args);
 
-    if let Some(target_dir) = &args.target_dir {
-        line.arg("--target-dir");
-        line.arg(target_dir);
-    }
-
     if let Some(color) = args.color {
         line.arg("--color");
         line.arg(color.as_str());

--- a/src/process.rs
+++ b/src/process.rs
@@ -30,8 +30,6 @@ pub(crate) struct ProcessBuilder {
 
     /// Any environment variables that should be set for the program.
     env: HashMap<String, Option<OsString>>,
-    /// The directory to run the program from.
-    cwd: Option<OsString>,
     /// Use verbose output.
     verbose: bool,
 }
@@ -45,7 +43,6 @@ impl ProcessBuilder {
             trailing_args: Rc::from(&[][..]),
             args: Vec::new(),
             features: String::new(),
-            cwd: None,
             env: HashMap::new(),
             verbose: false,
         }
@@ -59,7 +56,6 @@ impl ProcessBuilder {
             trailing_args: args.trailing_args.clone(),
             args: Vec::new(),
             features: String::new(),
-            cwd: None,
             env: HashMap::new(),
             verbose: args.verbose,
         }
@@ -117,12 +113,6 @@ impl ProcessBuilder {
     //     self
     // }
 
-    // /// (chainable) Sets the current working directory of the process.
-    // pub(crate) fn cwd(&mut self, path: impl AsRef<OsStr>) -> &mut Self {
-    //     self.cwd = Some(path.as_ref().to_os_string());
-    //     self
-    // }
-
     // /// (chainable) Sets an environment variable for the process.
     // pub(crate) fn env(&mut self, key: &str, val: impl AsRef<OsStr>) -> &mut Self {
     //     self.env.insert(key.to_string(), Some(val.as_ref().to_os_string()));
@@ -144,11 +134,6 @@ impl ProcessBuilder {
     // pub(crate) fn get_args(&self) -> &[OsString] {
     //     &self.args
     // }
-
-    /// Gets the current working directory for the process.
-    pub(crate) fn get_cwd(&self) -> Option<&Path> {
-        self.cwd.as_ref().map(Path::new)
-    }
 
     // /// Gets an environment variable as the process will see it (will inherit from environment
     // /// unless explicitally unset).
@@ -205,9 +190,6 @@ impl ProcessBuilder {
     /// present.
     fn build_command(&self) -> Command {
         let mut command = Command::new(&*self.program);
-        if let Some(cwd) = self.get_cwd() {
-            command.current_dir(cwd);
-        }
 
         command.args(&*self.leading_args);
         command.args(&self.args);


### PR DESCRIPTION
We no longer change current_dir so we don't need to handle this on our own.