### PR TITLE
Add `--feature-powerset` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "anyhow 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-ext 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -50,6 +51,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -199,6 +213,8 @@ dependencies = [
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum easy-ext 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ed79d40452cc72aa676b63ddde7f415865b412984738a1ba11096615ab0b262c"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ A tool to work around some limitations on cargo.
 [dependencies]
 anyhow = "1.0.22"
 ctrlc = "3.1.3"
+itertools = "0.8.2"
 serde = "1.0.102"
 # Depends directly on `serde_derive` instead of using `derive` feature of
 # `serde` to reduce compile time. When pipeline compilation for proc-macro is

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ To install the current cargo-hack requires Rust 1.36 or later.
 
   This is a workaround for an issue that cargo does not support for `--features` and `--no-default-features` flags for sub crates ([cargo#3620], [cargo#4106], [cargo#4463], [cargo#4753], [cargo#5015], [cargo#5364], [cargo#6195]).
 
+* **`--feature-powerset`**
+
+  Perform for the feature powerset which includes `--no-default-features` and
+  default features of the package.
+
+  This is useful to check that every combination of features is working
+  properly. (When used for this purpose, it is recommended to use with
+  `--no-dev-deps` to avoid [cargo#4866].)
+
+  ```sh
+  cargo hack check --feature-powerset --no-dev-deps
+  ```
+
 * **`--no-dev-deps`**
 
   Perform without dev-dependencies.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,9 @@ OPTIONS:
         --each-feature              Perform for each feature which includes
                                     `--no-default-features` and default features
                                     of the package
+        --feature-powerset          Perform for the feature powerset which
+                                    includes `--no-default-features` and
+                                    default features of the package
         --no-dev-deps               Perform without dev-dependencies
         --remove-dev-deps           Equivalent to `--no-dev-deps` except for
                                     does not restore the original `Cargo.toml`
@@ -74,6 +77,8 @@ pub(crate) struct Args {
     pub(crate) workspace: bool,
     /// --each-feature
     pub(crate) each_feature: bool,
+    /// --feature-powerset
+    pub(crate) feature_powerset: bool,
     /// --no-dev-deps
     pub(crate) no_dev_deps: bool,
     /// --remove-dev-deps
@@ -156,6 +161,7 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<Result<Args, i32>>
     let mut no_dev_deps = false;
     let mut remove_dev_deps = false;
     let mut each_feature = false;
+    let mut feature_powerset = false;
     let mut ignore_private = false;
     let mut ignore_unknown_features = false;
     let mut ignore_non_exist_features = false;
@@ -276,6 +282,12 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<Result<Args, i32>>
                     }
                     each_feature = true;
                 }
+                "--feature-powerset" => {
+                    if feature_powerset {
+                        return Err(multi_arg(&arg, subcommand.as_ref()));
+                    }
+                    feature_powerset = true;
+                }
                 "--ignore-private" => {
                     if ignore_private {
                         return Err(multi_arg(&arg, subcommand.as_ref()));
@@ -392,6 +404,7 @@ For more information try --help
         exclude,
         workspace: workspace.is_some(),
         each_feature,
+        feature_powerset,
         no_dev_deps,
         remove_dev_deps,
         ignore_private,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@ mod process;
 mod remove_dev_deps;
 mod restore;
 
-use std::{env, ffi::OsString, fs, path::Path};
 use anyhow::{bail, Context, Error};
 use itertools;
+use std::{env, ffi::OsString, fs, path::Path};
 
 use crate::{
     cli::{Args, Coloring},

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -506,6 +506,27 @@ fn test_each_feature() {
 }
 
 #[test]
+fn test_feature_powerset() {
+    let output = cargo_hack()
+        .args(&["hack", "check", "--feature-powerset"])
+        .current_dir(test_dir("tests/fixtures/real"))
+        .output()
+        .unwrap();
+
+    output
+        .assert_success()
+        .assert_stderr_contains("running `cargo check` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features a` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features b` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features c` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features a,b` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features a,c` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features b,c` on real")
+        .assert_stderr_contains("running `cargo check --no-default-features --features a,b,c` on real");
+}
+
+#[test]
 fn test_each_feature2() {
     let output = cargo_hack()
         .args(&["hack", "check", "--each-feature", "--features=a"])

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -520,10 +520,18 @@ fn test_feature_powerset() {
         .assert_stderr_contains("running `cargo check --no-default-features --features a` on real")
         .assert_stderr_contains("running `cargo check --no-default-features --features b` on real")
         .assert_stderr_contains("running `cargo check --no-default-features --features c` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features a,b` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features a,c` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features b,c` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features a,b,c` on real");
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,b` on real",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,c` on real",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b,c` on real",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,b,c` on real",
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

I have recently been using `cargo-hack` for the `--each-feature` subcommand.
It has been very helpful! However, I have been testing feature combinations
manually.

The crate I've been using this for supports any combination of features, so it
seemed like a `--feature-powerset` subcommand could be useful to contribute.
