### PR TITLE
Print the total number of feature flag combinations and progress

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -360,6 +360,9 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<Option<Args>> {
     if no_dev_deps && remove_dev_deps {
         bail!("--no-dev-deps may not be used together with --remove-dev-deps");
     }
+    if each_feature && feature_powerset {
+        bail!("--each-feature may not be used together with --feature-powerset");
+    }
 
     if subcommand.is_none() {
         if leading.iter().any(|a| a == "--list") {

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,0 +1,163 @@
+use std::{fmt::Write, ops::Deref};
+
+use crate::*;
+
+pub(crate) fn features(
+    args: &Args,
+    package: &Package<'_>,
+    line: &ProcessBuilder,
+    info: &mut Info,
+) -> Result<()> {
+    Features { args, package, line: line.clone(), info }.exec()
+}
+
+pub(crate) struct Package<'a> {
+    package: &'a metadata::Package,
+    pub(crate) manifest: Manifest,
+    pub(crate) kind: Kind<'a>,
+}
+
+impl<'a> Package<'a> {
+    fn new(
+        args: &'a Args,
+        package: &'a metadata::Package,
+        total: &mut usize,
+    ) -> Result<Option<Self>> {
+        let manifest = Manifest::new(&package.manifest_path)?;
+
+        if args.ignore_private && manifest.is_private() {
+            Ok(Some(Self { package, manifest, kind: Kind::Skip }))
+        } else if args.subcommand.is_some() {
+            let (kind, count) = Kind::collect(args, package);
+            *total += count;
+            Ok(Some(Self { package, manifest, kind }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) fn from_iter(
+        args: &'a Args,
+        total: &mut usize,
+        packages: impl IntoIterator<Item = &'a metadata::Package>,
+    ) -> Result<Vec<Self>> {
+        packages
+            .into_iter()
+            .filter_map(|package| Package::new(args, package, total).transpose())
+            .collect::<Result<Vec<_>>>()
+    }
+}
+
+impl Deref for Package<'_> {
+    type Target = metadata::Package;
+    fn deref(&self) -> &Self::Target {
+        self.package
+    }
+}
+
+pub(crate) enum Kind<'a> {
+    Skip,
+    Nomal { show_progress: bool },
+    Each { features: Vec<&'a String> },
+    Powerset { features: Vec<Vec<&'a String>> },
+}
+
+impl<'a> Kind<'a> {
+    fn collect(args: &'a Args, package: &'a metadata::Package) -> (Self, usize) {
+        if (!args.each_feature && !args.feature_powerset) || package.features.is_empty() {
+            return (Kind::Nomal { show_progress: args.each_feature || args.feature_powerset }, 1);
+        }
+
+        let features =
+            package.features.keys().filter(|k| (*k != "default" && !args.skip.contains(k)));
+        if args.each_feature {
+            let features: Vec<_> = features.collect();
+            // +1: default features
+            // +1: no default features
+            let total = features.len() + 2;
+            (Kind::Each { features }, total)
+        } else if args.feature_powerset {
+            let features = powerset(features);
+            // +1: default features
+            // +1: no default features
+            // -1: the first element of a powerset is `[]`
+            let total = features.len() + 1;
+            (Kind::Powerset { features }, total)
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+struct Features<'a> {
+    args: &'a Args,
+    package: &'a Package<'a>,
+    line: ProcessBuilder,
+    info: &'a mut Info,
+}
+
+impl Features<'_> {
+    fn exec(&mut self) -> Result<()> {
+        if let Kind::Nomal { show_progress } = &self.package.kind {
+            // run with default features
+            return self.exec_cargo(None, *show_progress);
+        }
+
+        // run with default features
+        self.exec_cargo(None, true)?;
+
+        self.line.arg("--no-default-features");
+
+        // run with no default features if the package has other features
+        //
+        // `default` is not skipped because `cfg(feature = "default")` is work
+        // if `default` feature specified.
+        self.exec_cargo(None, true)?;
+
+        match &self.package.kind {
+            Kind::Each { features } => {
+                features.iter().try_for_each(|f| self.exec_cargo_with_features(Some(f)))
+            }
+            Kind::Powerset { features } => {
+                // The first element of a powerset is `[]` so it should be skipped.
+                features.iter().skip(1).try_for_each(|f| self.exec_cargo_with_features(f))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn exec_cargo_with_features(
+        &mut self,
+        features: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<()> {
+        let mut line = self.line.clone();
+        line.append_features(features);
+        self.exec_cargo(Some(&line), true)
+    }
+
+    fn exec_cargo(&mut self, line: Option<&ProcessBuilder>, show_progress: bool) -> Result<()> {
+        let line = line.unwrap_or(&self.line);
+        self.info.count += 1;
+
+        // running `<command>` on <package> (<count>/<total>)
+        let mut msg = String::new();
+        write!(msg, "running {} on {}", line, &self.package.name).unwrap();
+        if show_progress {
+            write!(msg, " ({}/{})", self.info.count, self.info.total).unwrap();
+        }
+        info!(self.args.color, "{}", msg);
+
+        line.exec()
+    }
+}
+
+fn powerset<'a, T>(iter: impl IntoIterator<Item = &'a T>) -> Vec<Vec<&'a T>> {
+    iter.into_iter().fold(vec![vec![]], |mut acc, elem| {
+        let ext = acc.clone().into_iter().map(|mut curr| {
+            curr.push(elem);
+            curr
+        });
+        acc.extend(ext);
+        acc
+    })
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::Context;
 
-use crate::{Args, Package, Result};
+use crate::{metadata::Package, Args, Result};
 
 // Based on https://github.com/rust-lang/cargo/blob/0.39.0/src/cargo/util/process_builder.rs
 
@@ -74,7 +74,7 @@ impl ProcessBuilder {
                     // ignored
                     info!(
                         args.color,
-                        "skipped applying unknown `{}` feature to {}", f, package.name
+                        "skipped applying unknown `{}` feature to {}", f, package.name,
                     );
                     false
                 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -31,7 +31,7 @@ impl Output {
     fn assert_success(&self) -> &Self {
         if !self.status.success() {
             panic!(
-                "`self.status.success()`:\nSTDOUT:\n```\n{}\n```\n\nSTDERR:\n```\n{}\n```\n",
+                "`self.status.success()`:\n\nSTDOUT:\n```\n{}\n```\n\nSTDERR:\n```\n{}\n```\n",
                 self.stdout(),
                 self.stderr(),
             )
@@ -41,7 +41,7 @@ impl Output {
     fn assert_failure(&self) -> &Self {
         if self.status.success() {
             panic!(
-                "`!self.status.success()`:\nSTDOUT:\n```\n{}\n```\n\nSTDERR:\n```\n{}\n```\n",
+                "`!self.status.success()`:\n\nSTDOUT:\n```\n{}\n```\n\nSTDERR:\n```\n{}\n```\n",
                 self.stdout(),
                 self.stderr(),
             )
@@ -51,7 +51,7 @@ impl Output {
     fn assert_stderr_contains(&self, pat: &str) -> &Self {
         if !self.stderr().contains(pat) {
             panic!(
-                "`self.stderr().contains(pat)`:\nPAT:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
+                "`self.stderr().contains(..)`:\n\nEXPECTED:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
                 pat,
                 self.stderr()
             )
@@ -61,7 +61,7 @@ impl Output {
     fn assert_stderr_not_contains(&self, pat: &str) -> &Self {
         if self.stderr().contains(pat) {
             panic!(
-                "`!self.stderr().contains(pat)`:\nPAT:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
+                "`!self.stderr().contains(..)`:\n\nUNEXPECTED:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
                 pat,
                 self.stderr()
             )
@@ -71,7 +71,7 @@ impl Output {
     fn assert_stdout_contains(&self, pat: &str) -> &Self {
         if !self.stdout().contains(pat) {
             panic!(
-                "`self.stdout().contains(pat)`:\nPAT:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
+                "`self.stdout().contains(..)`:\n\nEXPECTED:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
                 pat,
                 self.stdout()
             )
@@ -81,7 +81,7 @@ impl Output {
     fn assert_stdout_not_contains(&self, pat: &str) -> &Self {
         if self.stdout().contains(pat) {
             panic!(
-                "`!self.stdout().contains(pat)`:\nPAT:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
+                "`!self.stdout().contains(..)`:\n\nUNEXPECTED:\n```\n{}\n```\n\nACTUAL:\n```\n{}\n```\n",
                 pat,
                 self.stdout()
             )
@@ -447,11 +447,17 @@ fn test_each_feature() {
         .output()
         .unwrap()
         .assert_success()
-        .assert_stderr_contains("running `cargo check` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features a` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features b` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features c` on real");
+        .assert_stderr_contains("running `cargo check` on real (1/5)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real (2/5)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on real (3/5)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on real (4/5)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features c` on real (5/5)",
+        );
 }
 
 #[test]
@@ -462,22 +468,28 @@ fn test_feature_powerset() {
         .output()
         .unwrap()
         .assert_success()
-        .assert_stderr_contains("running `cargo check` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features a` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features b` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features c` on real")
+        .assert_stderr_contains("running `cargo check` on real (1/9)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real (2/9)")
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features a,b` on real",
+            "running `cargo check --no-default-features --features a` on real (3/9)",
         )
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features a,c` on real",
+            "running `cargo check --no-default-features --features b` on real (4/9)",
         )
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features b,c` on real",
+            "running `cargo check --no-default-features --features c` on real (6/9)",
         )
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features a,b,c` on real",
+            "running `cargo check --no-default-features --features a,b` on real (5/9)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,c` on real (7/9)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b,c` on real (8/9)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,b,c` on real (9/9)",
         );
 }
 
@@ -502,10 +514,14 @@ fn test_each_feature_skip_success() {
         .output()
         .unwrap()
         .assert_success()
-        .assert_stderr_contains("running `cargo check` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features b` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features c` on real")
+        .assert_stderr_contains("running `cargo check` on real (1/4)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real (2/4)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on real (3/4)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features c` on real (4/4)",
+        )
         .assert_stderr_not_contains(
             "running `cargo check --no-default-features --features a` on real",
         );
@@ -548,16 +564,72 @@ fn test_each_feature2() {
         .output()
         .unwrap()
         .assert_success()
-        .assert_stderr_contains("running `cargo check --features a` on real")
-        .assert_stderr_contains("running `cargo check --no-default-features --features a` on real")
+        .assert_stderr_contains("running `cargo check --features a` on real (1/5)")
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features a,a` on real",
+            "running `cargo check --no-default-features --features a` on real (2/5)",
         )
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features a,b` on real",
+            "running `cargo check --no-default-features --features a,a` on real (3/5)",
         )
         .assert_stderr_contains(
-            "running `cargo check --no-default-features --features a,c` on real",
+            "running `cargo check --no-default-features --features a,b` on real (4/5)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,c` on real (5/5)",
+        );
+}
+
+#[test]
+fn test_each_feature_all() {
+    cargo_hack()
+        .args(&["check", "--each-feature", "--workspace"])
+        .current_dir(test_dir("tests/fixtures/real"))
+        .output()
+        .unwrap()
+        .assert_success()
+        .assert_stderr_contains("running `cargo check` on member1 (1/20)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on member1 (2/20)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on member1 (3/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on member1 (4/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features c` on member1 (5/20)",
+        )
+        .assert_stderr_contains("running `cargo check` on member2 (6/20)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on member2 (7/20)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on member2 (8/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on member2 (9/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features c` on member2 (10/20)",
+        )
+        .assert_stderr_contains("running `cargo check` on member3 (11/20)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on member3 (12/20)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on member3 (13/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on member3 (14/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features c` on member3 (15/20)",
+        )
+        .assert_stderr_contains("running `cargo check` on real (16/20)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real (17/20)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on real (18/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on real (19/20)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features c` on real (20/20)",
         );
 }
 


### PR DESCRIPTION
Before:

```txt
$ cargo hack --each-feature --workspace
info: running `cargo check` on crate1
...
info: running `cargo check --no-default-features` on crate1
...
info: running `cargo check` on crate2
...
```

After:

```txt
$ cargo hack --each-feature --workspace
info: running `cargo check` on crate1 (1/10)
...
info: running `cargo check --no-default-features` on crate1 (2/10)
...
info: running `cargo check` on crate2 (6/10)
...
```

This is only enabled for `--each-feature` and `--feature-powerset` that may run the command multiple times with one crate.

Closes #27