### PR TITLE
Remove --ignore-non-exist-features flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+* Remove `--ignore-non-exist-features` flag, use `--ignore-unknown-features` flag instead.
+
 * Treat `--all-features` flag as one of feature combinations. See [#42][42] for details.
 
 * Add `--skip-all-features` flag. See [#42][42] for details.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -186,7 +186,7 @@ pub(crate) struct Args {
     pub(crate) remove_dev_deps: bool,
     /// --ignore-private
     pub(crate) ignore_private: bool,
-    /// --ignore-unknown-features, (--ignore-non-exist-features)
+    /// --ignore-unknown-features
     pub(crate) ignore_unknown_features: bool,
     /// --optional-deps [DEPS]...
     pub(crate) optional_deps: Option<Vec<String>>,
@@ -276,7 +276,6 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<Option<Args>> {
     let mut feature_powerset = false;
     let mut ignore_private = false;
     let mut ignore_unknown_features = false;
-    let mut ignore_non_exist_features = false;
     let mut skip_no_default_features = false;
     let mut skip_all_features = false;
     let mut clean_per_run = false;
@@ -422,18 +421,10 @@ pub(crate) fn args(coloring: &mut Option<Coloring>) -> Result<Option<Args>> {
                 "--skip-no-default-features" => parse_flag!(skip_no_default_features),
                 "--skip-all-features" => parse_flag!(skip_all_features),
                 "--clean-per-run" => parse_flag!(clean_per_run),
-                "--ignore-unknown-features" => {
-                    if ignore_unknown_features || ignore_non_exist_features {
-                        return Err(multi_arg(&arg, subcommand.as_ref()));
-                    }
-                    ignore_unknown_features = true;
-                }
-                "--ignore-non-exist-features" => {
-                    if ignore_unknown_features || ignore_non_exist_features {
-                        return Err(multi_arg("--ignore-unknown-features", subcommand.as_ref()));
-                    }
-                    ignore_non_exist_features = true;
-                }
+                "--ignore-unknown-features" => parse_flag!(ignore_unknown_features),
+                "--ignore-non-exist-features" => bail!(
+                    "`--ignore-non-exist-features` flag was removed, use `--ignore-unknown-features` flag instead"
+                ),
                 // allow multiple uses
                 "--verbose" | "-v" | "-vv" => verbose = true,
                 _ => leading.push(arg),
@@ -535,12 +526,6 @@ For more information try --help
         }
     }
 
-    if ignore_non_exist_features {
-        warn!(
-            color,
-            "'--ignore-non-exist-features' flag is deprecated, use '--ignore-unknown-features' flag instead"
-        );
-    }
     if no_dev_deps {
         info!(
             color,
@@ -564,7 +549,7 @@ For more information try --help
         no_dev_deps,
         remove_dev_deps,
         ignore_private,
-        ignore_unknown_features: ignore_unknown_features || ignore_non_exist_features,
+        ignore_unknown_features,
         optional_deps,
         skip_no_default_features,
         skip_all_features,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -125,8 +125,7 @@ fn multi_arg() {
         "--ignore-private",
         "--ignore-unknown-features",
         "--optional-deps",
-    ][..]
-    {
+    ] {
         cargo_hack()
             .args(&["check", flag, flag])
             .current_dir(test_dir("tests/fixtures/real"))
@@ -140,7 +139,7 @@ fn multi_arg() {
     }
 
     for (flag, msg) in
-        &[("--manifest-path", "--manifest-path <PATH>"), ("--color", "--color <WHEN>")][..]
+        &[("--manifest-path", "--manifest-path <PATH>"), ("--color", "--color <WHEN>")]
     {
         cargo_hack()
             .args(&["check", flag, "auto", flag, "auto"])
@@ -151,6 +150,22 @@ fn multi_arg() {
             .assert_stderr_contains(&format!(
                 "The argument '{}' was provided more than once, but cannot be used multiple times",
                 msg
+            ));
+    }
+}
+
+#[test]
+fn removed_flags() {
+    for (flag, alt) in &[("--ignore-non-exist-features", "--ignore-unknown-features")] {
+        cargo_hack()
+            .args(&["check", flag])
+            .current_dir(test_dir("tests/fixtures/real"))
+            .output()
+            .unwrap()
+            .assert_failure()
+            .assert_stderr_contains(&format!(
+                "`{}` flag was removed, use `{}` flag instead",
+                flag, alt
             ));
     }
 }
@@ -483,19 +498,6 @@ fn ignore_unknown_features() {
         .assert_stderr_contains(
             "running `cargo check --no-default-features --features f` on member2",
         );
-
-    // --ignore-non-exist-features is a deprecated alias of --ignore-unknown-features
-    cargo_hack()
-        .args(&["check", "--ignore-non-exist-features", "--features=f"])
-        .current_dir(test_dir("tests/fixtures/virtual"))
-        .output()
-        .unwrap()
-        .assert_success()
-        .assert_stderr_contains("'--ignore-non-exist-features' flag is deprecated, use '--ignore-unknown-features' flag instead")
-        .assert_stderr_contains("skipped applying unknown `f` feature to member1")
-        .assert_stderr_contains("running `cargo check` on member1")
-        .assert_stderr_not_contains("skipped applying unknown `f` feature to member2")
-        .assert_stderr_contains("running `cargo check --features f` on member2");
 }
 
 #[test]


### PR DESCRIPTION
This flag has been deprecated since the 0.2.0 release.