### PR TITLE
Add --exclude-features as an alias of --skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 * Treat `--all-features` flag as one of feature combinations. See [#42][42] for details.
 
-* Add `--skip-all-features` flag. See [#42][42] for details.
+* Add `--exclude-all-features` flag. See [#42][42] for details.
+
+* Add `--exclude-features` option. This is an alias of `--skip` option.
+
+* Rename `--skip-no-default-features` flag to `--exclude-no-default-features`.
+  The old name can be used as an alias, but is deprecated.
 
 * Fix an issue where using `--features` with `--each-feature` or `--feature-powerset` together would result in the same feature combination being performed multiple times.
 

--- a/README.md
+++ b/README.md
@@ -96,15 +96,9 @@ The following flags can be used with `--each-feature` and `--feature-powerset`.
 
   Use optional dependencies as features.
 
-* **`--skip`**
+* **`--exclude-features`**, **`--skip`**
 
-  Space-separated list of features to skip.
-
-  To skip run of default feature, using value `--skip default`.
-
-* **`--skip-no-default-features`**
-
-  Skip run of just `--no-default-features` flag.
+  Space-separated list of features to exclude.
 
 * **`--depth`**
 

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -45,19 +45,22 @@ OPTIONS:
             This flag can only be used together with either --each-feature flag or --feature-powerset flag.
 
         --skip <FEATURES>...
-            Space-separated list of features to skip.
+            Alias for --exclude-features.
 
-            To skip run of default feature, using value `--skip default`.
+        --exclude-features <FEATURES>...
+            Space-separated list of features to exclude.
 
-            This flag can only be used together with either --each-feature flag or --feature-powerset flag.
-
-        --skip-no-default-features
-            Skip run of just --no-default-features flag.
+            To exclude run of default feature, using value `--exclude-features default`.
 
             This flag can only be used together with either --each-feature flag or --feature-powerset flag.
 
-        --skip-all-features
-            Skip run of just --all-features flag.
+        --exclude-no-default-features
+            Exclude run of just --no-default-features flag.
+
+            This flag can only be used together with either --each-feature flag or --feature-powerset flag.
+
+        --exclude-all-features
+            Exclude run of just --all-features flag.
 
             This flag can only be used together with either --each-feature flag or --feature-powerset flag.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -7,28 +7,29 @@ USAGE:
 Use -h for short descriptions and --help for more details.
 
 OPTIONS:
-    -p, --package <SPEC>...        Package(s) to check
-        --all                      Alias for --workspace
-        --workspace                Perform command for all packages in the workspace
-        --exclude <SPEC>...        Exclude packages from the check
-        --manifest-path <PATH>     Path to Cargo.toml
-        --features <FEATURES>...   Space-separated list of features to activate
-        --each-feature             Perform for each feature of the package
-        --feature-powerset         Perform for the feature powerset of the package
-        --optional-deps [DEPS]...  Use optional dependencies as features
-        --skip <FEATURES>...       Space-separated list of features to skip
-        --skip-no-default-features Skip run of just --no-default-features flag
-        --skip-all-features        Skip run of just --all-features flag
-        --depth <NUM>              Specify a max number of simultaneous feature flags of --feature-powerset
-        --no-dev-deps              Perform without dev-dependencies
-        --remove-dev-deps          Equivalent to --no-dev-deps flag except for does not restore the original `Cargo.toml` after performed
-        --ignore-private           Skip to perform on `publish = false` packages
-        --ignore-unknown-features  Skip passing --features flag to `cargo` if that feature does not exist in the package
-        --clean-per-run            Remove artifacts for that package before running the command
-    -v, --verbose                  Use verbose output
-        --color <WHEN>             Coloring: auto, always, never
-    -h, --help                     Prints help information
-    -V, --version                  Prints version information
+    -p, --package <SPEC>...              Package(s) to check
+        --all                            Alias for --workspace
+        --workspace                      Perform command for all packages in the workspace
+        --exclude <SPEC>...              Exclude packages from the check
+        --manifest-path <PATH>           Path to Cargo.toml
+        --features <FEATURES>...         Space-separated list of features to activate
+        --each-feature                   Perform for each feature of the package
+        --feature-powerset               Perform for the feature powerset of the package
+        --optional-deps [DEPS]...        Use optional dependencies as features
+        --skip <FEATURES>...             Alias for --exclude-features
+        --exclude-features <FEATURES>... Space-separated list of features to exclude
+        --exclude-no-default-features    Exclude run of just --no-default-features flag
+        --exclude-all-features           Exclude run of just --all-features flag
+        --depth <NUM>                    Specify a max number of simultaneous feature flags of --feature-powerset
+        --no-dev-deps                    Perform without dev-dependencies
+        --remove-dev-deps                Equivalent to --no-dev-deps flag except for does not restore the original `Cargo.toml` after performed
+        --ignore-private                 Skip to perform on `publish = false` packages
+        --ignore-unknown-features        Skip passing --features flag to `cargo` if that feature does not exist in the package
+        --clean-per-run                  Remove artifacts for that package before running the command
+    -v, --verbose                        Use verbose output
+        --color <WHEN>                   Coloring: auto, always, never
+    -h, --help                           Prints help information
+    -V, --version                        Prints version information
 
 Some common cargo commands are (see all commands with --list):
         build       Compile the current package


### PR DESCRIPTION
* Add `--exclude-features` option. This is an alias of `--skip` option.
* Rename `--skip-no-default-features` flag to `--exclude-no-default-features`.
  The old name can be used as an alias, but is deprecated.
* Rename `--skip-all-features` flag to `--exclude-all-features`.

cc #52 