### PR TITLE
Add --include-features option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 * Rename `--skip-no-default-features` flag to `--exclude-no-default-features`.
   The old name can be used as an alias, but is deprecated.
 
+* Add `--include-features` option.
+
 * Fix an issue where using `--features` with `--each-feature` or `--feature-powerset` together would result in the same feature combination being performed multiple times.
 
 [42]: https://github.com/taiki-e/cargo-hack/pull/42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,28 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-* Remove `--ignore-non-exist-features` flag, use `--ignore-unknown-features` flag instead.
+* [Remove `--ignore-non-exist-features` flag.][62] Use `--ignore-unknown-features` flag instead.
 
-* Treat `--all-features` flag as one of feature combinations. See [#42][42] for details.
+* [Treat `--all-features` flag as one of feature combinations.][61] See [#42][42] for details.
 
-* Add `--exclude-all-features` flag. See [#42][42] for details.
+* Add `--exclude-all-features` flag. ([#61][61], [#65][65]) See [#42][42] for details.
 
-* Add `--exclude-features` option. This is an alias of `--skip` option.
+* [Add `--exclude-features` option. This is an alias of `--skip` option.][65]
 
-* Rename `--skip-no-default-features` flag to `--exclude-no-default-features`.
+* [Rename `--skip-no-default-features` flag to `--exclude-no-default-features`.][65]
   The old name can be used as an alias, but is deprecated.
 
-* Add `--include-features` option.
+* [Add `--include-features` option.][66] See [#66][66] for details.
 
-* Fix an issue where using `--features` with `--each-feature` or `--feature-powerset` together would result in the same feature combination being performed multiple times.
+* [Fix an issue where using `--features` with `--each-feature` or `--feature-powerset` together would result in the same feature combination being performed multiple times.][64]
 
 [42]: https://github.com/taiki-e/cargo-hack/pull/42
+[61]: https://github.com/taiki-e/cargo-hack/pull/61
+[62]: https://github.com/taiki-e/cargo-hack/pull/62
+[63]: https://github.com/taiki-e/cargo-hack/pull/63
+[64]: https://github.com/taiki-e/cargo-hack/pull/64
+[65]: https://github.com/taiki-e/cargo-hack/pull/65
+[66]: https://github.com/taiki-e/cargo-hack/pull/66
 
 ## [0.3.14] - 2020-10-10
 

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -52,6 +52,10 @@ OPTIONS:
 
             To exclude run of default feature, using value `--exclude-features default`.
 
+            To exclude run of just --no-default-features flag, using --exclude-no-default-features flag.
+
+            To exclude run of just --all-features flag, using --exclude-all-features flag.
+
             This flag can only be used together with either --each-feature flag or --feature-powerset flag.
 
         --exclude-no-default-features
@@ -71,6 +75,11 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --include-features <FEATURES>...
+            Include only the specified features in the feature combinations instead of package features.
+
+            This flag can only be used together with either --each-feature flag or --feature-powerset flag.
+
         --no-dev-deps
             Perform without dev-dependencies.
 
@@ -85,7 +94,7 @@ OPTIONS:
         --ignore-unknown-features
             Skip passing --features flag to `cargo` if that feature does not exist in the package.
 
-            This flag can only be used in the root of a virtual workspace or together with --workspace.
+            This flag can only be used together with either --features or --include-features.
 
         --clean-per-run
             Remove artifacts for that package before running the command.

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -21,6 +21,7 @@ OPTIONS:
         --exclude-no-default-features    Exclude run of just --no-default-features flag
         --exclude-all-features           Exclude run of just --all-features flag
         --depth <NUM>                    Specify a max number of simultaneous feature flags of --feature-powerset
+        --include-features <FEATURES>... Include only the specified features in the feature combinations instead of package features
         --no-dev-deps                    Perform without dev-dependencies
         --remove-dev-deps                Equivalent to --no-dev-deps flag except for does not restore the original `Cargo.toml` after performed
         --ignore-private                 Skip to perform on `publish = false` packages

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -498,7 +498,7 @@ fn ignore_unknown_features_failure() {
         .unwrap()
         .assert_failure()
         .assert_stderr_contains(
-            "--ignore-unknown-features can only be used together with --features",
+            "--ignore-unknown-features can only be used together with either --features or --include-features",
         );
 }
 
@@ -652,6 +652,49 @@ fn depth_failure() {
         .unwrap()
         .assert_failure()
         .assert_stderr_contains("--depth can only be used together with --feature-powerset");
+}
+
+#[test]
+fn include_features() {
+    cargo_hack()
+        .args(&["check", "--each-feature", "--include-features", "a,b"])
+        .current_dir(test_dir("tests/fixtures/real"))
+        .output()
+        .unwrap()
+        .assert_success()
+        .assert_stderr_contains("running `cargo check` on real (1/5)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real (2/5)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on real (3/5)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on real (4/5)",
+        )
+        .assert_stderr_not_contains("--features c")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --all-features` on real (5/5)",
+        );
+
+    cargo_hack()
+        .args(&["check", "--feature-powerset", "--include-features", "a,b"])
+        .current_dir(test_dir("tests/fixtures/real"))
+        .output()
+        .unwrap()
+        .assert_success()
+        .assert_stderr_contains("running `cargo check` on real (1/6)")
+        .assert_stderr_contains("running `cargo check --no-default-features` on real (2/6)")
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a` on real (3/6)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features b` on real (4/6)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --features a,b` on real (5/6)",
+        )
+        .assert_stderr_contains(
+            "running `cargo check --no-default-features --all-features` on real (6/6)",
+        );
 }
 
 #[test]


### PR DESCRIPTION
```text
--include-features <FEATURES>...
    Include only the specified features in the feature combinations instead of package features.

    This flag can only be used together with either --each-feature flag or --feature-powerset flag.
```

Closes #52