### PR TITLE
Do not read manifest if information from manifest is not required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           # This is the minimum supported Rust version of this crate.
           # When updating this, the reminder to update the minimum supported Rust version in README.md.
           - 1.36.0
+          - 1.38.0
+          - 1.39.0
           - stable
           - beta
           - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 * [Fix an issue where using `--features` with `--each-feature` or `--feature-powerset` together would result in the same feature combination being performed multiple times.][64]
 
+* [Improve performance by avoiding reading and parsing Cargo manifest.][73]
+
 [42]: https://github.com/taiki-e/cargo-hack/pull/42
 [61]: https://github.com/taiki-e/cargo-hack/pull/61
 [62]: https://github.com/taiki-e/cargo-hack/pull/62
@@ -28,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org).
 [64]: https://github.com/taiki-e/cargo-hack/pull/64
 [65]: https://github.com/taiki-e/cargo-hack/pull/65
 [66]: https://github.com/taiki-e/cargo-hack/pull/66
+[73]: https://github.com/taiki-e/cargo-hack/pull/73
 
 ## [0.3.14] - 2020-10-10
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,6 +233,13 @@ pub(crate) struct Args<'a> {
     pub(crate) color: Option<Coloring>,
 }
 
+impl Args<'_> {
+    /// Return `true` if options that require information from cargo manifest is specified.
+    pub(crate) fn require_manifest_info(&self, version: u32) -> bool {
+        (version < 39 && self.ignore_private) || self.no_dev_deps || self.remove_dev_deps
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum Coloring {
     Auto,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod metadata;
 mod process;
 mod remove_dev_deps;
 mod restore;
+mod version;
 
 use anyhow::{bail, Context as _};
 use std::{fmt::Write, fs};
@@ -86,7 +87,7 @@ enum Kind<'a> {
 }
 
 fn determine_kind<'a>(cx: &'a Context<'_>, id: &PackageId, progress: &mut Progress) -> Kind<'a> {
-    if cx.ignore_private && cx.manifests(id).is_private() {
+    if cx.ignore_private && cx.is_private(id) {
         return Kind::SkipAsPrivate;
     }
     if cx.subcommand.is_none() {
@@ -185,10 +186,10 @@ fn determine_package_list<'a>(
             .filter(|id| cx.package.contains(&&*cx.packages(id).name))
             .map(|id| (id, determine_kind(cx, id, progress)))
             .collect()
-    } else if cx.current_manifest().is_none() {
+    } else if cx.current_package().is_none() {
         cx.workspace_members().map(|id| (id, determine_kind(cx, id, progress))).collect()
     } else {
-        let current_package = &cx.manifests(cx.current_manifest().unwrap()).package.name;
+        let current_package = &cx.packages(cx.current_package().unwrap()).name;
         cx.workspace_members()
             .find(|id| cx.packages(id).name == *current_package)
             .map(|id| vec![(id, determine_kind(cx, id, progress))])

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,44 @@
+use anyhow::{format_err, Context as _};
+use std::{ffi::OsStr, str};
+
+use crate::{ProcessBuilder, Result};
+
+pub(crate) struct Version {
+    pub(crate) minor: u32,
+}
+
+pub(crate) fn from_path(path: &OsStr) -> Result<Version> {
+    let mut command = ProcessBuilder::new(path);
+    command.args(&["--version", "--verbose"]);
+    let output = command.exec_with_output()?;
+
+    let output = str::from_utf8(&output.stdout)
+        .with_context(|| format!("failed to parse output of {}", command))?;
+
+    // Find the release line in the verbose version output.
+    let release = output
+        .lines()
+        .find(|line| line.starts_with("release: "))
+        .map(|line| &line["release: ".len()..])
+        .ok_or_else(|| format_err!("could not find rustc release from output of {}", command))?;
+
+    // Split the version and channel info.
+    let mut version_channel = release.split('-');
+    let version = version_channel.next().unwrap();
+    let _channel = version_channel.next();
+
+    let minor = (|| {
+        // Split the version into semver components.
+        let mut digits = version.splitn(3, '.');
+        let major = digits.next()?;
+        if major != "1" {
+            return None;
+        }
+        let minor = digits.next()?.parse().ok()?;
+        let _patch = digits.next()?;
+        Some(minor)
+    })()
+    .ok_or_else(|| format_err!("unexpected output from {}", command))?;
+
+    Ok(Version { minor })
+}


### PR DESCRIPTION
Very few options require information from Cargo manifest, so it can improve performance by avoiding reading and parsing them in many cases.