### PR TITLE
Add --group-features option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+* [Add `--group-features` option.][82]
+
+[82]: https://github.com/taiki-e/cargo-hack/pull/82
+
 ## [0.4.0] - 2020-10-21
 
 * [Remove `--ignore-non-exist-features` flag.][62] Use `--ignore-unknown-features` flag instead.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ The following flags can be used with `--each-feature` and `--feature-powerset`.
 
   If the number is set to 1, `--feature-powerset` is equivalent to `--each-feature`.
 
+* **`--group-features`**
+
+  Space-separated list of features to group.
+
+  To specify multiple groups, use this option multiple times: `--group-features a,b --group-features c,d`
+
 `cargo-hack` changes the behavior of the following existing flags.
 
 * **`--features`**, **`--no-default-features`**

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -248,6 +248,14 @@ impl Package {
             Cow::Borrowed(&self.name)
         }
     }
+
+    pub(crate) fn features(&self) -> impl Iterator<Item = &str> {
+        self.features.iter().map(String::as_str)
+    }
+
+    pub(crate) fn optional_deps(&self) -> impl Iterator<Item = &str> {
+        self.dependencies.iter().filter_map(Dependency::as_feature)
+    }
 }
 
 /// A dependency of the main crate

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -75,6 +75,13 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --group-features <FEATURES>...
+            Space-separated list of features to group.
+
+            To specify multiple groups, use this option multiple times: `--group-features a,b --group-features c,d`
+
+            This flag can only be used together with --feature-powerset flag.
+
         --include-features <FEATURES>...
             Include only the specified features in the feature combinations instead of package features.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -21,6 +21,7 @@ OPTIONS:
         --exclude-no-default-features    Exclude run of just --no-default-features flag
         --exclude-all-features           Exclude run of just --all-features flag
         --depth <NUM>                    Specify a max number of simultaneous feature flags of --feature-powerset
+        --group-features <FEATURES>...   Space-separated list of features to group
         --include-features <FEATURES>... Include only the specified features in the feature combinations instead of package features
         --no-dev-deps                    Perform without dev-dependencies
         --remove-dev-deps                Equivalent to --no-dev-deps flag except for does not restore the original `Cargo.toml` after performed


### PR DESCRIPTION
Closes #80

```text
--group-features <FEATURES>...
    Space-separated list of features to group.

    To specify multiple groups, use this option multiple times: `--group-features a,b --group-features c,d`

    This flag can only be used together with --feature-powerset flag.
```

```console
$ cargo hack check --feature-powerset --group-features a,b
info: running `cargo check --no-default-features` on crate1 (1/5)
...
info: running `cargo check --no-default-features --features c` on crate1 (2/5)
...
info: running `cargo check --no-default-features --features a,b` on crate1 (3/5)
...
info: running `cargo check --no-default-features --features c,a,b` on crate1 (4/5)
...
info: running `cargo check --no-default-features --all-features` on crate1 (5/5)
...
```