### PR TITLE
ci: Distribute compiled binary files via GitHub release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,25 @@ jobs:
             rust: nightly
           - os: windows-latest
             rust: nightly
+          - os: windows-latest
+            rust: nightly-x86_64-gnu
+          - os: ubuntu-latest
+            rust: nightly
+            target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: ci/install-rust.sh ${{ matrix.rust }}
-      - if: matrix.rust == 'nightly'
+      - if: startsWith(matrix.rust, 'nightly') && matrix.target == ''
         run: cargo install cargo-hack
-      - run: cargo test
-      - if: matrix.rust == 'nightly'
+      - if: matrix.target != ''
+        run: cargo install cross
+      - if: matrix.target != ''
+        run: cross test --target ${{ matrix.target }}
+      - if: matrix.target == ''
+        run: cargo test
+      - if: startsWith(matrix.rust, 'nightly') && matrix.target == ''
         run: bash scripts/check-minimal-versions.sh
 
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -D warnings
+  RUST_BACKTRACE: 1
+
 defaults:
   run:
     shell: bash
@@ -16,5 +21,31 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ci/create-release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    if: github.repository_owner == 'taiki-e'
+    needs:
+      - create-release
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: ci/install-rust.sh
+      # Work around https://github.com/actions/cache/issues/403 by using GNU tar
+      # instead of BSD tar.
+      - name: Install GNU tar
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gnu-tar
+          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> "${GITHUB_PATH}"
+      - run: ci/upload-assets.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/upload-assets.sh
+++ b/ci/upload-assets.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+ref="${GITHUB_REF:?}"
+tag="${ref#*/tags/}"
+
+export CARGO_PROFILE_RELEASE_LTO=true
+host=$(rustc -Vv | grep host | sed 's/host: //')
+
+package="cargo-hack"
+cargo build --bin "${package}" --release
+
+cd target/release
+case "${OSTYPE}" in
+  linux* | darwin*)
+    asset="${package}-${tag}-${host}.tar.gz"
+    tar czf ../../"${asset}" "${package}"
+    ;;
+  cygwin* | msys*)
+    asset="${package}-${tag}-${host}.zip"
+    7z a ../../"${asset}" "${package}".exe
+    ;;
+  *)
+    echo "unrecognized OSTYPE: ${OSTYPE}"
+    exit 1
+    ;;
+esac
+cd ../..
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN not set, skipping deploy"
+  exit 1
+else
+  gh release upload "${tag}" "${asset}" --clobber
+fi


### PR DESCRIPTION
If you install locally, I basically recommend using `cargo install`, but given that one of cargo-hack's main purposes is to use it in CI, it makes sense to distribute the compiled binary files.