### PR TITLE
ci: Remove version number from release binaries

### DIFF
--- a/ci/upload-assets.sh
+++ b/ci/upload-assets.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+cd "$(cd "$(dirname "${0}")" && pwd)"/..
+
 ref="${GITHUB_REF:?}"
 tag="${ref#*/tags/}"
 
@@ -16,12 +18,18 @@ cd target/release
 case "${OSTYPE}" in
   linux* | darwin*)
     strip "${package}"
-    asset="${package}-${tag}-${host}.tar.gz"
+    asset="${package}-${host}.tar.gz"
+    # TODO: remove this when release the next major version.
+    asset2="${package}-${tag}-${host}.tar.gz"
     tar czf ../../"${asset}" "${package}"
+    tar czf ../../"${asset2}" "${package}"
     ;;
   cygwin* | msys*)
-    asset="${package}-${tag}-${host}.zip"
+    asset="${package}-${host}.zip"
+    # TODO: remove this when release the next major version.
+    asset2="${package}-${tag}-${host}.zip"
     7z a ../../"${asset}" "${package}".exe
+    7z a ../../"${asset2}" "${package}".exe
     ;;
   *)
     echo "unrecognized OSTYPE: ${OSTYPE}"
@@ -34,5 +42,5 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   echo "GITHUB_TOKEN not set, skipping deploy"
   exit 1
 else
-  gh release upload "${tag}" "${asset}" --clobber
+  gh release upload "${tag}" "${asset}" "${asset2}" --clobber
 fi


### PR DESCRIPTION
See also https://github.com/taiki-e/cargo-hack/pull/89#issuecomment-726026807

This allows installing cargo-hack with one command if you know the host os.
before(current):

```sh
version=$(curl -LsSf https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | jq -r '.name')
curl -LsSf https://github.com/taiki-e/cargo-hack/releases/download/v${version}/cargo-hack-v${version}-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
```

after:

```sh
curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
```

Script for cross-platform installing to be also a bit simpler.
before(current): https://github.com/taiki-e/cargo-hack/pull/89#issuecomment-723754842
after:

```sh
host=$(rustc -Vv | grep host | sed 's/host: //')
if [[ $host =~ windows ]]; then
    curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-${host}.zip -o cargo-hack.zip
    7z x cargo-hack.zip -o~/.cargo/bin
elif [[ $host =~ darwin|linux ]]; then
    curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-${host}.tar.gz | tar xzf - -C ~/.cargo/bin
else
    echo "unsupported operating system"
    exit 1
fi
```

To prevent breaking the CI that depends on the current URL, we will distribute under both names until the next major version (0.5).
