### PR TITLE
ci: Improve distribution via GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,25 +22,20 @@ jobs:
   test:
     strategy:
       matrix:
-        rust:
+        include:
           # This is the minimum supported Rust version of this crate.
           # When updating this, the reminder to update the minimum supported Rust version in README.md.
-          - 1.36.0
-          - 1.39.0
-          - 1.41.0
-          - stable
-          - beta
-        include:
-          - os: ubuntu-latest
-            rust: nightly
-          - os: macos-latest
-            rust: nightly
-          - os: windows-latest
-            rust: nightly
-          - os: windows-latest
-            rust: nightly-x86_64-gnu
-          - os: ubuntu-latest
-            rust: nightly
+          - rust: 1.36.0
+          - rust: 1.39.0
+          - rust: 1.41.0
+          - rust: stable
+          - rust: beta
+          - rust: nightly
+          - rust: nightly
+            os: macos-latest
+          - rust: nightly
+            os: windows-latest
+          - rust: nightly
             target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
@@ -63,8 +58,8 @@ jobs:
     strategy:
       matrix:
         rust:
-        # cargo-hack is usually runnable with Cargo versions older than the Rust version required for installation.
-        # When updating this, the reminder to update the minimum supported Rust version in README.md.
+          # cargo-hack is usually runnable with Cargo versions older than the Rust version required for installation.
+          # When updating this, the reminder to update the minimum supported Rust version in README.md.
           - 1.26.0
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,26 +25,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:
+    name: ${{ matrix.target }}
     if: github.repository_owner == 'taiki-e'
     needs:
       - create-release
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+        include:
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-unknown-linux-musl
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
       - uses: taiki-e/github-actions/install-rust@main
       # Work around https://github.com/actions/cache/issues/403 by using GNU tar
       # instead of BSD tar.
       - name: Install GNU tar
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         run: |
           brew install gnu-tar
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> "${GITHUB_PATH}"
-      - run: ci/upload-assets.sh
+      - run: ci/upload-assets.sh ${{ matrix.target }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Distribute `*.tar.gz` file for Windows. The current Windows 10 has bsdtar by default, so this makes it easy to install cross-platform.

  ```sh
  host=$(rustc -Vv | grep host | sed 's/host: //')
  curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-"$host".tar.gz | tar xzf - -C ~/.cargo/bin
  ```

* Distribute x86_64-unknown-linux-musl binary.