### PR TITLE
Add --version-range option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,22 @@ jobs:
       - if: startsWith(matrix.rust, 'nightly') && matrix.target == ''
         run: bash scripts/check-minimal-versions.sh
 
+  build:
+    strategy:
+      matrix:
+        range:
+          # This is the minimum supported Rust version of this crate.
+          # When updating this, the reminder to update the minimum supported Rust version in README.md.
+          - 1.36..1.40
+          - 1.41..1.45
+          - 1.46..
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # TODO: replace this with `cargo install cargo-hack` when cargo-hack 0.5.0 released
+      - run: cargo +stable install --path .
+      - run: cargo hack build --all --ignore-private --no-dev-deps --version-range ${{ matrix.range }}
+
   run:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ cargo-hack is usually runnable with Cargo versions older than the Rust version r
 
   Remove artifacts for that package before running the command.
 
+  This also works as a workaround for [rust-lang/rust-clippy#4612].
+
+* **`--version-range`**
+
+  Perform commands on a specified (inclusive) range of Rust versions.
+
+  ```console
+  $ cargo hack check --version-range 1.46..1.47
+  info: running `cargo +1.46 check` on cargo-hack (1/2)
+  ...
+  info: running `cargo +1.47 check` on cargo-hack (2/2)
+  ...
+  ```
+
+  If the given range is unclosed, the latest stable compiler is treated as the upper bound.
+
+  This might be useful for catching issues like [BurntSushi/termcolor#35], [rust-lang/regex#685], [rust-lang/rust-clippy#6324].
+
+  [BurntSushi/termcolor#35]: https://github.com/BurntSushi/termcolor/issues/35
+  [rust-lang/regex#685]: https://github.com/rust-lang/regex/issues/685
+  [rust-lang/rust-clippy#6324]: https://github.com/rust-lang/rust-clippy/issues/6324.
+
+* **`--version-step`**
+
+  Specify the version interval of `--version-range`.
+
 The following flags can be used with `--each-feature` and `--feature-powerset`.
 
 * **`--optional-deps`**
@@ -141,6 +167,7 @@ The following flags can be used with `--each-feature` and `--feature-powerset`.
 [rust-lang/cargo#5015]: https://github.com/rust-lang/cargo/issues/4463
 [rust-lang/cargo#5364]: https://github.com/rust-lang/cargo/issues/5364
 [rust-lang/cargo#6195]: https://github.com/rust-lang/cargo/issues/6195
+[rust-lang/rust-clippy#4612]: https://github.com/rust-lang/cargo/issues/4612
 [cargo-metadata]: https://doc.rust-lang.org/cargo/commands/cargo-metadata.html
 
 ## License

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,7 @@ use crate::{
     features::Features,
     manifest::Manifest,
     metadata::{Metadata, Package, PackageId},
-    Cargo, ProcessBuilder, Result,
+    Cargo, ProcessBuilder, Result, Rustup,
 };
 
 pub(crate) struct Context<'a> {
@@ -26,9 +26,10 @@ pub(crate) struct Context<'a> {
 impl<'a> Context<'a> {
     pub(crate) fn new(args: &'a RawArgs) -> Result<Self> {
         let cargo = Cargo::new();
+        let rustup = Rustup::new();
         let current_dir = env::current_dir()?;
 
-        let args = cli::parse_args(args, &cargo)?;
+        let args = cli::parse_args(args, &cargo, &rustup)?;
         assert!(
             args.subcommand.is_some() || args.remove_dev_deps,
             "no subcommand or valid flag specified"
@@ -112,7 +113,7 @@ impl<'a> Context<'a> {
         (self.cargo.version < 39 && self.ignore_private) || self.no_dev_deps || self.remove_dev_deps
     }
 
-    pub(crate) fn process(&self) -> ProcessBuilder<'_> {
+    pub(crate) fn cargo(&self) -> ProcessBuilder<'_> {
         let mut cmd = self.cargo.process();
         if self.verbose {
             cmd.display_manifest_path();

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -1,0 +1,104 @@
+use anyhow::{bail, format_err, Context as _};
+use std::str;
+
+use crate::{
+    cargo,
+    version::{parse_version, Version},
+    ProcessBuilder, Result,
+};
+
+pub(crate) struct Rustup {
+    pub(crate) version: u32,
+}
+
+impl Rustup {
+    pub(crate) fn new() -> Self {
+        // If failed to determine rustup version, assign 0 to skip all version-dependent decisions.
+        let version = minor_version()
+            .map_err(|e| warn!("unable to determine rustup version: {:#}", e))
+            .unwrap_or(0);
+
+        Self { version }
+    }
+}
+
+pub(crate) fn version_range(range: &str, step: Option<&str>) -> Result<Vec<String>> {
+    let check = |version: &Version| {
+        if version.major != 1 {
+            bail!("major version must be 1");
+        }
+        if let Some(patch) = version.patch {
+            warn!(
+                "--version-range always selects the latest patch release per minor release, \
+                     not the specified patch release `{}`",
+                patch
+            )
+        }
+        Ok(())
+    };
+
+    let mut split = range.splitn(2, "..");
+    let start = split.next().map(parse_version).unwrap()?;
+    check(&start)?;
+
+    let end = match split.next() {
+        Some("") | None => {
+            install_toolchain("stable")?;
+            cargo::minor_version(ProcessBuilder::new("cargo".as_ref()).args(&["+stable"]))?
+        }
+        Some(end) => {
+            let end = parse_version(end)?;
+            check(&end)?;
+            end.minor
+        }
+    };
+
+    let step = step.map(str::parse::<u8>).transpose()?.unwrap_or(1);
+    if step == 0 {
+        bail!("--version-step cannot be zero");
+    }
+
+    let versions: Vec<_> =
+        (start.minor..=end).step_by(step as _).map(|minor| format!("+1.{}", minor)).collect();
+    if versions.is_empty() {
+        bail!("specified version range `{}` is empty", range);
+    }
+    Ok(versions)
+}
+
+pub(crate) fn install_toolchain(toolchain: &str) -> Result<()> {
+    // In Github Actions and Azure Pipelines, --no-self-update is necessary
+    // because the windows environment cannot self-update rustup.exe.
+    rustup()
+        .args(&["toolchain", "install", toolchain, "--no-self-update"])
+        .exec_with_output()
+        .map(drop)
+}
+
+fn rustup<'a>() -> ProcessBuilder<'a> {
+    ProcessBuilder::new("rustup".as_ref())
+}
+
+fn minor_version() -> Result<u32> {
+    let mut cmd = rustup();
+    cmd.args(&["--version"]);
+    let output = cmd.exec_with_output()?;
+
+    let output = str::from_utf8(&output.stdout)
+        .with_context(|| format!("failed to parse output of {}", cmd))?;
+
+    let version = (|| {
+        let mut output = output.split(' ');
+        if output.next()? != "rustup" {
+            return None;
+        }
+        output.next()
+    })()
+    .ok_or_else(|| format_err!("unexpected output from {}: {}", cmd, output))?;
+    let version = parse_version(version)?;
+    if version.major != 1 || version.patch.is_none() {
+        bail!("unexpected output from {}: {}", cmd, output);
+    }
+
+    Ok(version.minor)
+}

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -110,6 +110,16 @@ OPTIONS:
 
             Note that dependencies artifacts will be preserved.
 
+        --version-range <START>..[END]
+            Perform commands on a specified (inclusive) range of Rust versions.
+
+            If the given range is unclosed, the latest stable compiler is treated as the upper bound.
+
+            Note that ranges are always inclusive ranges.
+
+        --version-step <NUM>
+            Specify the version interval of --version-range.
+
     -v, --verbose
             Use verbose output.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -28,6 +28,8 @@ OPTIONS:
         --ignore-private                 Skip to perform on `publish = false` packages
         --ignore-unknown-features        Skip passing --features flag to `cargo` if that feature does not exist in the package
         --clean-per-run                  Remove artifacts for that package before running the command
+        --version-range <START>..[END]   Perform commands on a specified (inclusive) range of Rust versions
+        --version-step <NUM>             Specify the version interval of --version-range
     -v, --verbose                        Use verbose output
         --color <WHEN>                   Coloring: auto, always, never
     -h, --help                           Prints help information


### PR DESCRIPTION
Closes #93
> This may be useful for catching issues like https://github.com/BurntSushi/termcolor/issues/35, https://github.com/rust-lang/regex/issues/685, https://github.com/rayon-rs/rayon/pull/761#discussion_r428639158, https://github.com/rust-lang/rust-clippy/issues/6324.

```text
--version-range <START>..[END]
    Perform commands on a specified (inclusive) range of Rust versions.

    If the given range is unclosed, the latest stable compiler is treated as the upper bound.

    Note that ranges are always inclusive ranges.

--version-step <NUM>
    Specify the version interval of --version-range.
```


Note: Ranges are always **inclusive** ranges. (`start..=end`)

```console
$ cargo hack check --version-range 1.46..1.47
info: running `cargo +1.46 check` on cargo-hack (1/2)
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
info: running `cargo +1.47 check` on cargo-hack (2/2)
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
```

If the given range is unclosed, the latest stable compiler is treated as the upper bound.

```console
$ cargo hack check --version-range 1.46..
info: running `cargo +1.46 check` on cargo-hack (1/3)
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
info: running `cargo +1.47 check` on cargo-hack (2/3)
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
info: running `cargo +1.48 check` on cargo-hack (3/3)
    Finished dev [unoptimized + debuginfo] target(s) in 0.28
```

You can also specify the version interval by using `--version-step`. (`(start..=end).step_by(step)`)

```console
$ cargo hack check --version-range 1.45.. --version-step 2
info: running `cargo +1.45 check` on cargo-hack (1/2)
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
info: running `cargo +1.47 check` on cargo-hack (2/2)
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
```