### PR TITLE
Use terminal_size instead of term_size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 anyhow = "1.0.34"
 ctrlc = { version = "3.1.4", features = ["termination"] }
 serde_json = "1"
-term_size = "0.3"
 termcolor = "1"
+terminal_size = "0.1.16"
 toml = "0.5.2"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -633,11 +633,17 @@ struct Help {
 
 impl Help {
     fn long() -> Self {
-        Self { long: true, term_size: term_size::dimensions().map_or(120, |(w, _)| w) }
+        Self {
+            long: true,
+            term_size: terminal_size::terminal_size().map_or(120, |(width, _)| width.0 as _),
+        }
     }
 
     fn short() -> Self {
-        Self { long: false, term_size: term_size::dimensions().map_or(120, |(w, _)| w) }
+        Self {
+            long: false,
+            term_size: terminal_size::terminal_size().map_or(120, |(width, _)| width.0 as _),
+        }
     }
 }
 


### PR DESCRIPTION
term_size is unmaintained.
Refs: https://github.com/clap-rs/term_size-rs/tree/5889fdc589d267182cc946faa24e0e3166a70000#maintenance-status