### PR TITLE
Add --clean-per-version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `--clean-per-version` flag.
+
 ## [0.5.4] - 2021-02-27
 
 - [Stop commit of `Cargo.lock`.](https://github.com/taiki-e/cargo-hack/pull/117)

--- a/README.md
+++ b/README.md
@@ -94,12 +94,6 @@ Skip to perform on `publish = false` packages.
 
 Skip passing `--features` to `cargo` if that feature does not exist.
 
-### --clean-per-run
-
-Remove artifacts for that package before running the command.
-
-This also works as a workaround for [rust-clippy#4612].
-
 ### --version-range
 
 Perform commands on a specified (inclusive) range of Rust versions.
@@ -121,6 +115,12 @@ This might be useful for catching issues like [termcolor#35], [regex#685],
 ### --version-step
 
 Specify the version interval of `--version-range`.
+
+### --clean-per-run
+
+Remove artifacts for that package before running the command.
+
+This also works as a workaround for [rust-clippy#4612].
 
 ### Options for adjusting the behavior of --each-feature and --feature-powerset
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,11 @@ fn exec_on_workspace(cx: &Context<'_>) -> Result<()> {
             if i != 0 {
                 rustup::install_toolchain(toolchain, cx.target, true)?;
             }
+
+            if cx.clean_per_version {
+                cargo_clean(cx, None)?;
+            }
+
             let mut line = line.clone();
             line.leading_arg(toolchain);
             line.with_args(cx);
@@ -357,7 +362,7 @@ fn exec_cargo(
     progress.count += 1;
 
     if cx.clean_per_run {
-        cargo_clean(cx, id)?;
+        cargo_clean(cx, Some(id))?;
     }
 
     // running `<command>` (on <package>) (<count>/<total>)
@@ -373,14 +378,16 @@ fn exec_cargo(
     line.exec()
 }
 
-fn cargo_clean(cx: &Context<'_>, id: &PackageId) -> Result<()> {
+fn cargo_clean(cx: &Context<'_>, id: Option<&PackageId>) -> Result<()> {
     let mut line = cx.cargo();
     line.arg("clean");
-    line.arg("--package");
-    line.arg(&cx.packages(id).name);
+    if let Some(id) = id {
+        line.arg("--package");
+        line.arg(&cx.packages(id).name);
+    }
 
     if cx.verbose {
-        // running `cargo clean --package <package>`
+        // running `cargo clean [--package <package>]`
         info!("running {}", line);
     }
 

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -103,13 +103,6 @@ OPTIONS:
 
             This flag can only be used together with either --features or --include-features.
 
-        --clean-per-run
-            Remove artifacts for that package before running the command.
-
-            If used this flag with --workspace, --each-feature, or --feature-powerset, artifacts will be removed before each run.
-
-            Note that dependencies artifacts will be preserved.
-
         --version-range <START>..[END]
             Perform commands on a specified (inclusive) range of Rust versions.
 
@@ -119,6 +112,22 @@ OPTIONS:
 
         --version-step <NUM>
             Specify the version interval of --version-range.
+
+            This flag can only be used together with --version-range flag.
+
+        --clean-per-run
+            Remove artifacts for that package before running the command.
+
+            If used this flag with --workspace, --each-feature, or --feature-powerset, artifacts will be removed before each run.
+
+            Note that dependencies artifacts will be preserved.
+
+        --clean-per-version
+            Remove artifacts per Rust version.
+
+            Note that dependencies artifacts will also be removed.
+
+            This flag can only be used together with --version-range flag.
 
     -v, --verbose
             Use verbose output.

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -27,9 +27,10 @@ OPTIONS:
         --remove-dev-deps                Equivalent to --no-dev-deps flag except for does not restore the original `Cargo.toml` after performed
         --ignore-private                 Skip to perform on `publish = false` packages
         --ignore-unknown-features        Skip passing --features flag to `cargo` if that feature does not exist in the package
-        --clean-per-run                  Remove artifacts for that package before running the command
         --version-range <START>..[END]   Perform commands on a specified (inclusive) range of Rust versions
         --version-step <NUM>             Specify the version interval of --version-range
+        --clean-per-run                  Remove artifacts for that package before running the command
+        --clean-per-version              Remove artifacts per Rust version
     -v, --verbose                        Use verbose output
         --color <WHEN>                   Coloring: auto, always, never
     -h, --help                           Prints help information

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,6 +2,8 @@
 
 mod auxiliary;
 
+use std::env;
+
 use auxiliary::{cargo_bin_exe, cargo_hack, target_triple, CommandExt, SEPARATOR};
 
 #[test]
@@ -1326,4 +1328,16 @@ fn version_range_failure() {
             not the specified patch release `2`
             ",
         );
+}
+
+#[test]
+fn clean_per_version_failure() {
+    if env::var_os("CARGO_HACK_TEST_TOOLCHAIN").is_some() {
+        return;
+    }
+
+    // without --version-range
+    cargo_hack(["check", "--clean-per-version"])
+        .assert_failure("real")
+        .stderr_contains("--clean-per-version can only be used together with --version-range");
 }


### PR DESCRIPTION
```text
--clean-per-version
    Remove artifacts per Rust version.

    Note that dependencies artifacts will also be removed.

    This flag can only be used together with --version-range flag.
```

```console
$ cargo hack check --version-range 1.50.. --clean-per-version -v
info: running `cargo clean`
info: running `cargo +1.50 check --manifest-path Cargo.toml` (1/2)
   Compiling ...
    Finished dev [unoptimized + debuginfo] target(s) in 7.70s
info: running `cargo clean`
info: running `cargo +1.51 check --manifest-path Cargo.toml` (2/2)
   Compiling ...
    Finished dev [unoptimized + debuginfo] target(s) in 9.2
```

Closes #119 