### PR TITLE
Use stable cargo to get metadata when newer than cargo we actually use

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,6 @@
 msrv = "1.46"
+disallowed-methods = [
+    # https://internals.rust-lang.org/t/synchronized-ffi-access-to-posix-environment-variable-functions/15475
+    { path = "std::env::remove_var", reason = "this function should be considered `unsafe`" },
+    { path = "std::env::set_var", reason = "this function should be considered `unsafe`" },
+]

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ trim_trailing_whitespace = true
 [*.{json,md,yml}]
 indent_size = 2
 
+[Makefile]
+indent_style = tab
+
 [*.yml]
 quote_type = single
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 Cargo.lock
+tmp
 
 # For platform and editor specific settings, it is recommended to add to
 # a global .gitignore file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Fix an error when using old cargo with a dependency graph containing 2021 edition crates. ([#138](https://github.com/taiki-e/cargo-hack/pull/138))
+
 ## [0.5.8] - 2021-10-13
 
 - Distribute statically linked binary on Windows MSVC. ([#131](https://github.com/taiki-e/cargo-hack/pull/131))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.DEFAULT_GOAL := install
+.PHONY: install
+install:
+	@cargo install -f --path . --debug

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,30 +1,6 @@
-use std::{env, ffi::OsString};
-
 use anyhow::{bail, format_err, Result};
 
 use crate::{version::Version, ProcessBuilder};
-
-pub(crate) struct Cargo {
-    path: OsString,
-    pub(crate) version: u32,
-}
-
-impl Cargo {
-    pub(crate) fn new() -> Self {
-        let path = cargo_binary();
-
-        // If failed to determine cargo version, assign 0 to skip all version-dependent decisions.
-        let version = minor_version(process!(&path))
-            .map_err(|e| warn!("unable to determine cargo version: {:#}", e))
-            .unwrap_or(0);
-
-        Self { path, version }
-    }
-
-    pub(crate) fn process<'a>(&self) -> ProcessBuilder<'a> {
-        process!(&self.path)
-    }
-}
 
 // The version detection logic is based on https://github.com/cuviper/autocfg/blob/1.0.1/src/version.rs#L25-L59
 pub(crate) fn minor_version(mut cmd: ProcessBuilder<'_>) -> Result<u32> {
@@ -51,9 +27,4 @@ pub(crate) fn minor_version(mut cmd: ProcessBuilder<'_>) -> Result<u32> {
     }
 
     Ok(version.minor)
-}
-
-fn cargo_binary() -> OsString {
-    env::var_os("CARGO_HACK_CARGO_SRC")
-        .unwrap_or_else(|| env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo")))
 }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -5,37 +5,24 @@ use std::{
 
 use anyhow::Result;
 
-use crate::{fs, Context, PackageId};
+use crate::{fs, term};
 
 #[derive(Clone)]
-pub(crate) struct Restore {
+pub(crate) struct Manager {
     // A flag that indicates restore is needed.
-    needs_restore: bool,
-    // Information on manifest that needs to be restored next.
+    pub(crate) needs_restore: bool,
+    // Information on file that needs to be restored next.
     // If `needs_restore` is `false`, this is always `None`.
-    current: Arc<Mutex<Option<Current>>>,
+    current: Arc<Mutex<Option<File>>>,
 }
 
-struct Current {
-    manifest: String,
-    manifest_path: PathBuf,
-}
+impl Manager {
+    pub(crate) fn new(needs_restore: bool) -> Self {
+        let this = Self { needs_restore, current: Arc::new(Mutex::new(None)) };
 
-impl Restore {
-    pub(crate) fn new(cx: &Context<'_>) -> Self {
-        let this = Self {
-            // if `--remove-dev-deps` flag is off, restore manifest file.
-            needs_restore: cx.no_dev_deps && !cx.remove_dev_deps,
-            current: Arc::new(Mutex::new(None)),
-        };
-
-        if !this.needs_restore {
-            return this;
-        }
-
-        let x = this.clone();
+        let cloned = this.clone();
         ctrlc::set_handler(move || {
-            if let Err(e) = x.restore_dev_deps() {
+            if let Err(e) = cloned.restore() {
                 error!("{:#}", e);
                 std::process::exit(1)
             }
@@ -46,34 +33,48 @@ impl Restore {
         this
     }
 
-    pub(crate) fn set_manifest(&self, cx: &Context<'_>, id: &PackageId) -> Handle<'_> {
+    pub(crate) fn set(&self, text: impl Into<String>, path: impl Into<PathBuf>) -> Handle<'_> {
         if !self.needs_restore {
             return Handle(None);
         }
 
-        *self.current.lock().unwrap() = Some(Current {
-            manifest: cx.manifests(id).raw.clone(),
-            manifest_path: cx.packages(id).manifest_path.clone(),
-        });
+        *self.current.lock().unwrap() = Some(File { text: text.into(), path: path.into() });
 
         Handle(Some(self))
     }
 
-    fn restore_dev_deps(&self) -> Result<()> {
+    fn restore(&self) -> Result<()> {
         let mut current = self.current.lock().unwrap();
-        if let Some(current) = current.take() {
-            fs::write(&current.manifest_path, &current.manifest)?;
+        if let Some(file) = current.take() {
+            file.restore()?;
         }
         Ok(())
     }
 }
 
-pub(crate) struct Handle<'a>(Option<&'a Restore>);
+struct File {
+    /// The original text of this file.
+    text: String,
+    /// Path to this file.
+    path: PathBuf,
+}
+
+impl File {
+    fn restore(self) -> Result<()> {
+        if term::verbose() {
+            info!("restoring {}", self.path.display());
+        }
+        fs::write(&self.path, &self.text)
+    }
+}
+
+#[must_use]
+pub(crate) struct Handle<'a>(Option<&'a Manager>);
 
 impl Handle<'_> {
     pub(crate) fn close(&mut self) -> Result<()> {
-        if let Some(this) = self.0.take() {
-            this.restore_dev_deps()?;
+        if let Some(manager) = self.0.take() {
+            manager.restore()?;
         }
         Ok(())
     }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -41,7 +41,7 @@ pub(crate) fn version_range(range: &str, step: Option<&str>) -> Result<Vec<Strin
     let end = match split.next() {
         Some("") | None => {
             install_toolchain("stable", None, false)?;
-            cargo::minor_version(process!("cargo", "+stable"))?
+            cargo::minor_version(cmd!("cargo", "+stable"))?
         }
         Some(end) => {
             let end = end.parse()?;
@@ -73,7 +73,7 @@ pub(crate) fn install_toolchain(
     }
 
     if target.is_none()
-        && process!("cargo", format!("+{}", toolchain), "--version").run_with_output().is_ok()
+        && cmd!("cargo", format!("+{}", toolchain), "--version").run_with_output().is_ok()
     {
         // Do not run `rustup toolchain install` if the toolchain already has installed.
         return Ok(());
@@ -81,7 +81,7 @@ pub(crate) fn install_toolchain(
 
     // In Github Actions and Azure Pipelines, --no-self-update is necessary
     // because the windows environment cannot self-update rustup.exe.
-    let mut cmd = process!("rustup", "toolchain", "install", toolchain, "--no-self-update");
+    let mut cmd = cmd!("rustup", "toolchain", "add", toolchain, "--no-self-update");
     if let Some(target) = target {
         cmd.args(&["--target", target]);
     }
@@ -97,7 +97,7 @@ pub(crate) fn install_toolchain(
 }
 
 fn minor_version() -> Result<u32> {
-    let mut cmd = process!("rustup", "--version");
+    let mut cmd = cmd!("rustup", "--version");
     let output = cmd.read()?;
 
     let version = (|| {

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -26,7 +26,7 @@ pub fn cargo_bin_exe() -> Command {
 
 fn test_toolchain() -> String {
     if let Some(toolchain) = test_version() {
-        format!(" +1.{}", toolchain)
+        format!("+1.{} ", toolchain)
     } else {
         String::new()
     }
@@ -133,10 +133,12 @@ struct AssertOutputInner {
 
 #[track_caller]
 fn line_separated(lines: &str, f: impl FnMut(&str)) {
-    let lines = if lines.contains("`cargo +") {
+    let lines = if lines.contains("cargo +")
+        || lines.contains(&format!("cargo{} +", env::consts::EXE_SUFFIX))
+    {
         lines.to_string()
     } else {
-        lines.replace("`cargo", &format!("`cargo{}", test_toolchain()))
+        lines.replace("cargo ", &format!("cargo {}", test_toolchain()))
     };
     lines.split('\n').map(str::trim).filter(|line| !line.is_empty()).for_each(f);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1197,11 +1197,12 @@ fn list_separator() {
 fn verbose() {
     cargo_hack(["check", "--verbose"]).assert_success("virtual").stderr_contains(format!(
         "
-        running `cargo check --manifest-path member1{0}Cargo.toml`
-        running `cargo check --manifest-path member2{0}Cargo.toml`
-        running `cargo check --manifest-path dir{0}not_find_manifest{0}Cargo.toml`
+        cargo{1} check --manifest-path member1{0}Cargo.toml`
+        cargo{1} check --manifest-path member2{0}Cargo.toml`
+        cargo{1} check --manifest-path dir{0}not_find_manifest{0}Cargo.toml`
         ",
-        SEPARATOR
+        SEPARATOR,
+        env::consts::EXE_SUFFIX
     ));
 }
 


### PR DESCRIPTION
If failed, try again with the version of cargo we will actually use.

This fixes an error when using old cargo with a dependency graph
containing 2021 edition crates.

Closes #135