### PR TITLE
Support omitting lower bound of --version-range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: taiki-e/github-actions/install-rust@main
-        with:
-          toolchain: stable
+      - run: CARGO_HACK_TEST_TOOLCHAIN=${{ matrix.rust }} cargo test --all
+      # Remove stable toolchain to disable https://github.com/taiki-e/cargo-hack/pull/138's behavior.
+      - run: rustup toolchain remove stable
       - run: CARGO_HACK_TEST_TOOLCHAIN=${{ matrix.rust }} cargo test --all
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - Fix an error when using old cargo with a dependency graph containing 2021 edition crates. ([#138](https://github.com/taiki-e/cargo-hack/pull/138))
 
+- Support omitting lower bound of --version-range. ([#139](https://github.com/taiki-e/cargo-hack/pull/139))
+
 ## [0.5.8] - 2021-10-13
 
 - Distribute statically linked binary on Windows MSVC. ([#131](https://github.com/taiki-e/cargo-hack/pull/131))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{bail, format_err, Error, Result};
 
-use crate::{rustup, term, Feature, Rustup};
+use crate::{term, Feature, Rustup};
 
 pub(crate) struct Args<'a> {
     pub(crate) leading_args: Vec<&'a str>,
@@ -40,8 +40,10 @@ pub(crate) struct Args<'a> {
     pub(crate) clean_per_run: bool,
     /// --clean-per-version
     pub(crate) clean_per_version: bool,
-    /// --version-range and --version-step
-    pub(crate) version_range: Option<Vec<String>>,
+    /// --version-range
+    pub(crate) version_range: Option<&'a str>,
+    /// --version-step
+    pub(crate) version_step: Option<&'a str>,
 
     // options for --each-feature and --feature-powerset
     /// --optional-deps [DEPS]...
@@ -361,8 +363,6 @@ pub(crate) fn parse_args<'a>(raw: &'a [String], cargo: &OsStr) -> Result<Args<'a
             v.push(Feature::group(g));
             Ok(v)
         })?;
-    let version_range =
-        version_range.map(|range| rustup::version_range(range, version_step)).transpose()?;
 
     if let Some(subcommand) = subcommand {
         match subcommand {
@@ -499,6 +499,7 @@ pub(crate) fn parse_args<'a>(raw: &'a [String], cargo: &OsStr) -> Result<Args<'a
         include_features: include_features.into_iter().map(Into::into).collect(),
         include_deps_features,
         version_range,
+        version_step,
 
         depth,
         group_features,

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -45,6 +45,14 @@ fn test_version() -> Option<u32> {
     *TEST_VERSION
 }
 
+pub fn has_stable_toolchain() -> bool {
+    static HAS_STABLE_TOOLCHAIN: Lazy<Option<bool>> = Lazy::new(|| {
+        let output = Command::new("rustup").args(&["toolchain", "list"]).output().ok()?;
+        Some(String::from_utf8(output.stdout).ok()?.contains("stable"))
+    });
+    HAS_STABLE_TOOLCHAIN.unwrap_or_default()
+}
+
 pub fn cargo_hack<O: AsRef<OsStr>>(args: impl AsRef<[O]>) -> Command {
     let args = args.as_ref();
     let mut cmd = cargo_bin_exe();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,9 @@ mod auxiliary;
 
 use std::env;
 
-use auxiliary::{cargo_bin_exe, cargo_hack, target_triple, CommandExt, SEPARATOR};
+use auxiliary::{
+    cargo_bin_exe, cargo_hack, has_stable_toolchain, target_triple, CommandExt, SEPARATOR,
+};
 
 #[test]
 fn failures() {
@@ -590,7 +592,7 @@ fn powerset_deduplication_include_deps_features() {
     // TODO: Since easytime/default depends on easytime/std, their combination should be excluded,
     // but it's not working yet because include-deps-features itself isn't fully implemented.
     cargo_hack(["check", "--feature-powerset", "--include-deps-features"])
-        .assert_success2("powerset_deduplication", Some(41))
+        .assert_success2("powerset_deduplication",  Some(if has_stable_toolchain() { 34 } else { 41 }))
         .stderr_contains(
             "
             running `cargo check --no-default-features` on deduplication (1/41)
@@ -985,7 +987,7 @@ fn each_feature_all() {
 #[test]
 fn include_deps_features() {
     cargo_hack(["check", "--each-feature", "--include-deps-features"])
-        .assert_success2("powerset_deduplication", Some(41))
+        .assert_success2("powerset_deduplication",  Some(if has_stable_toolchain() { 34 } else { 41 }))
         .stderr_contains(
             "
             running `cargo check --no-default-features` on deduplication (1/9)


### PR DESCRIPTION
Closes #137 

```console
$ cargo hack check --version-range ..
info: running `cargo +1.46 check` on cargo-hack (1/12)
warning: /Users/taiki/projects/cargo-hack/Cargo.toml: unused manifest key: package.rust-version
    Checking cargo-hack v0.5.8 (/Users/taiki/projects/cargo-hack)
    Finished dev [unoptimized + debuginfo] target(s) in 1.34s
info: running `cargo +1.47 check` on cargo-hack (2/12)
warning: /Users/taiki/projects/cargo-hack/Cargo.toml: unused manifest key: package.rust-version
    Checking cargo-hack v0.5.8 (/Users/taiki/projects/cargo-hack)
    Finished dev [unoptimized + debuginfo] target(s) in 1.49s

...

info: running `cargo +1.56 check` on cargo-hack (11/12)
    Checking cargo-hack v0.5.8 (/Users/taiki/projects/cargo-hack)
    Finished dev [unoptimized + debuginfo] target(s) in 1.65s
info: running `cargo +1.57 check` on cargo-hack (12/12)
    Checking cargo-hack v0.5.8 (/Users/taiki/projects/cargo-hack)
    Finished dev [unoptimized + debuginfo] target(s) in 1.62s
```

```console
$ cargo hack check --version-range ..1.48`
info: running `cargo +1.46 check` on cargo-hack (1/3)
warning: /Users/taiki/projects/cargo-hack/Cargo.toml: unused manifest key: package.rust-version
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
info: running `cargo +1.47 check` on cargo-hack (2/3)
warning: /Users/taiki/projects/cargo-hack/Cargo.toml: unused manifest key: package.rust-version
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
info: running `cargo +1.48 check` on cargo-hack (3/3)
warning: /Users/taiki/projects/cargo-hack/Cargo.toml: unused manifest key: package.rust-version
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
```