### PR TITLE
Handle empty string in parse_multi_opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Allow empty strings in `--features` (`-F`), `--exclude-features` (`--skip`), `--include-features`.
+  Passing an empty string to them is now considered the same as not passing the flag. See [#163](https://github.com/taiki-e/cargo-hack/pull/163) for more.
+
 - Distribute prebuilt binaries for aarch64 Windows.
 
 ## [0.5.17] - 2022-08-12

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,11 +194,8 @@ impl Args {
                     {
                         val = &val[1..val.len() - 1];
                     }
-                    if val.contains(',') {
-                        $v.extend(val.split(',').map(str::to_owned));
-                    } else {
-                        $v.extend(val.split(' ').map(str::to_owned));
-                    }
+                    let sep = if val.contains(',') { ',' } else { ' ' };
+                    $v.extend(val.split(sep).filter(|s| !s.is_empty()).map(str::to_owned));
                 }};
             }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1414,3 +1414,10 @@ fn namespaced_features() {
             ",
         );
 }
+
+#[test]
+fn empty_string() {
+    cargo_hack(["check", "--each-feature", "--skip", ""])
+        .assert_success("real")
+        .stderr_not_contains("not found");
+}


### PR DESCRIPTION
This allows empty strings in `--features` (`-F`), `--exclude-features` (`--skip`), `--include-features`.
Passing an empty string to them is now considered the same as not passing the flag.

Closes #163