### PR TITLE
Support multitarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support multiple `--target` options. This uses cargo 1.64's [multi-target builds](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds) on cargo 1.64+, otherwise fallback to perform command per targets. ([#168](https://github.com/taiki-e/cargo-hack/pull/168))
+
 ## [0.5.19] - 2022-09-22
 
 - Fix "failed to parse `rust-version` field from manifest" error when workspace inheritance is used. ([#165](https://github.com/taiki-e/cargo-hack/pull/165))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,14 +75,12 @@ pub(crate) struct Args {
     // options that will be propagated to cargo
     /// --features <FEATURES>...
     pub(crate) features: Vec<String>,
+    /// --target <TRIPLE>...
+    pub(crate) target: Vec<String>,
 
     // propagated to cargo (as a part of leading_args)
     /// --no-default-features
     pub(crate) no_default_features: bool,
-    // Note: specifying multiple `--target` flags requires unstable `-Z multitarget`,
-    // so cargo-hack currently only supports a single `--target`.
-    /// --target <TRIPLE>...
-    pub(crate) target: Option<String>,
 }
 
 impl Args {
@@ -155,7 +153,7 @@ impl Args {
         let mut verbose = 0;
         let mut no_default_features = false;
         let mut all_features = false;
-        let mut target = None;
+        let mut target = vec![];
 
         let mut parser = lexopt::Parser::from_args(args);
         let mut next_flag: Option<OwnedFlag> = None;
@@ -209,7 +207,7 @@ impl Args {
 
             match arg {
                 Long("color") => parse_opt!(color, true),
-                Long("target") => parse_opt!(target, true),
+                Long("target") => target.push(parser.value()?.parse()?),
 
                 Long("manifest-path") => parse_opt!(manifest_path, false),
                 Long("depth") => parse_opt!(depth, false),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -46,11 +46,12 @@ pub(crate) struct Metadata {
 }
 
 impl Metadata {
-    pub(crate) fn new(args: &Args, cargo: &OsStr, restore: &restore::Manager) -> Result<Self> {
-        // If failed to determine cargo version, assign 0 to skip all version-dependent decisions.
-        let mut cargo_version = cargo::minor_version(cmd!(cargo))
-            .map_err(|e| warn!("unable to determine cargo version: {:#}", e))
-            .unwrap_or(0);
+    pub(crate) fn new(
+        args: &Args,
+        cargo: &OsStr,
+        mut cargo_version: u32,
+        restore: &restore::Manager,
+    ) -> Result<Self> {
         let stable_cargo_version = cargo::minor_version(cmd!("cargo", "+stable")).unwrap_or(0);
 
         let mut cmd;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1340,6 +1340,24 @@ fn version_range() {
             running `cargo +1.59 check --target x86_64-unknown-linux-musl` on real (2/2)
             ",
         );
+
+        cargo_hack([
+            "check",
+            "--version-range",
+            "1.63..1.64",
+            "--target",
+            "x86_64-unknown-linux-gnu",
+            "--target",
+            "x86_64-unknown-linux-musl",
+        ])
+        .assert_success("real")
+        .stderr_contains(
+            "
+            running `cargo +1.63 check --target x86_64-unknown-linux-gnu` on real (1/3)
+            running `cargo +1.63 check --target x86_64-unknown-linux-musl` on real (2/3)
+            running `cargo +1.64 check --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl` on real (3/3)
+            ",
+        );
     }
 }
 


### PR DESCRIPTION
This supports multiple `--target` options. This uses cargo 1.64's [multi-target builds](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds) on cargo 1.64+, otherwise fallback to perform command per targets.

```console
$ cargo hack build --target x86_64-apple-darwin --target aarch64-apple-darwin --version-range 1.63..1.64
info: running `cargo +1.63 build --target x86_64-apple-darwin` on cargo-hack (1/3)
...
info: running `cargo +1.63 build --target aarch64-apple-darwin` on cargo-hack (2/3)
...
info: running `cargo +1.64 build --target x86_64-apple-darwin --target aarch64-apple-darwin` on cargo-hack (3/3)
...
```

Closes #167