### PR TITLE
Add author to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["/.*", "/tools"]
 description = """
 Cargo subcommand to provide various options useful for testing and continuous integration.
 """
+authors = ["Taiki Endo <te316e89@gmail.com>", "cargo-hack Contributors"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
cargo-deb requires the author or copyright field be set.
> cargo-deb: The package must have a copyright or authors property

This fixes that, making it easier to package this project