### PR TITLE
Fix small nit on the `--exclude-features`/`--skip` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,12 @@ cargo hack check --feature-powerset --optional-deps deps1,deps2
 
 #### --exclude-features, --skip
 
-Space-separated list of features to exclude.
+Comma-separated list of features to exclude.
+
+```sh
+cargo hack check --feature-powerset --exclude-features feature1,feature2
+cargo hack check --feature-powerset --skip feature1,feature2
+```
 
 <!-- omit in toc -->
 #### --depth


### PR DESCRIPTION
Thank you for creating this project! I'm converting some invocations of `cargo-all-features` to use `cargo-hack` so I can make use of `cargo-nextest` instead of the normal test runner.

I noticed this small discrepancy in the documentation while doing this.