### PR TITLE
Implement --at-least-one-of

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --at-least-one-of <FEATURES>...
+            Space or comma separated list of features. Skips sets of features that don't enable any
+            of the features listed.
+
+            To specify multiple groups, use this option multiple times: `--at-least-one-of a,b
+            --at-least-one-of c,d`
+
+            This flag can only be used together with --feature-powerset flag.
+
         --include-features <FEATURES>...
             Include only the specified features in the feature combinations instead of package
             features.

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,8 @@ fn determine_kind<'a>(
             Kind::Each { features }
         }
     } else if cx.feature_powerset {
-        let features = features::feature_powerset(features, cx.depth, &package.features);
+        let features =
+            features::feature_powerset(features, cx.depth, &cx.at_least_one_of, &package.features);
 
         if (pkg_features.normal().is_empty() && pkg_features.optional_deps().is_empty()
             || !cx.include_features.is_empty())

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -97,6 +97,15 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --at-least-one-of <FEATURES>...
+            Space or comma separated list of features. Skips sets of features that don't enable any
+            of the features listed.
+
+            To specify multiple groups, use this option multiple times: `--at-least-one-of a,b
+            --at-least-one-of c,d`
+
+            This flag can only be used together with --feature-powerset flag.
+
         --include-features <FEATURES>...
             Include only the specified features in the feature combinations instead of package
             features.

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -23,6 +23,8 @@ OPTIONS:
         --depth <NUM>                    Specify a max number of simultaneous feature flags of
                                          --feature-powerset
         --group-features <FEATURES>...   Space or comma separated list of features to group
+        --at-least-one-of <FEATURES>...  Space or comma separated list of features. Skips sets of
+                                         features that don't enable any of the features listed
         --include-features <FEATURES>... Include only the specified features in the feature
                                          combinations instead of package features
         --no-dev-deps                    Perform without dev-dependencies


### PR DESCRIPTION
Skips powersets that don't contain any of the specified features. Can be used to test `cfg-if` chains of features where the last `else` is a compile error.

Fixes #182