### PR TITLE
Support ..= for --version-range

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,14 @@ OPTIONS:
 
             This flag can only be used together with either --features or --include-features.
 
-        --version-range <START>..[END]
+        --version-range [START]..[=END]
             Perform commands on a specified (inclusive) range of Rust versions.
 
-            If the given range is unclosed, the latest stable compiler is treated as the upper
-            bound.
+            If the upper bound of the range is omitted, the latest stable compiler is used as the
+            upper bound.
+
+            If the lower bound of the range is omitted, the value of the `rust-version` field in
+            `Cargo.toml` is used as the lower bound.
 
             Note that ranges are always inclusive ranges.
 
@@ -307,7 +310,7 @@ To specify multiple groups, use this option multiple times:
 Perform commands on a specified (inclusive) range of Rust versions.
 
 ```console
-$ cargo hack check --version-range 1.46..1.47
+$ cargo hack check --version-range 1.46..=1.47
 info: running `cargo +1.46 check` on cargo-hack (1/2)
 ...
 info: running `cargo +1.47 check` on cargo-hack (2/2)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -731,11 +731,13 @@ const HELP: &[HelpText<'_>] = &[
     (
         "",
         "--version-range",
-        "<START>..[END]",
+        "[START]..[=END]",
         "Perform commands on a specified (inclusive) range of Rust versions",
         &[
-            "If the given range is unclosed, the latest stable compiler is treated as the upper \
-             bound.",
+            "If the upper bound of the range is omitted, the latest stable compiler is used as the \
+             upper bound.",
+            "If the lower bound of the range is omitted, the value of the `rust-version` field in \
+             `Cargo.toml` is used as the lower bound.",
             "Note that ranges are always inclusive ranges.",
         ],
     ),

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -66,6 +66,16 @@ pub(crate) fn version_range(
             cargo::minor_version(cmd!("cargo", "+stable"))?
         }
         Some(end) => {
+            let end = match end.strip_prefix('=') {
+                Some(end) => end,
+                None => {
+                    warn!(
+                        "using `..` for inclusive range is deprecated; consider using `{}`",
+                        range.replace("..", "..=")
+                    );
+                    end
+                }
+            };
             let end = end.parse()?;
             check(&end)?;
             end.minor

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -62,7 +62,7 @@ pub fn cargo_hack<O: AsRef<OsStr>>(args: impl AsRef<[O]>) -> Command {
     cmd.arg("hack");
     if let Some(toolchain) = test_version() {
         if !args.iter().any(|a| a.as_ref().to_str().unwrap().starts_with("--version-range")) {
-            cmd.arg(format!("--version-range=1.{toolchain}..1.{toolchain}"));
+            cmd.arg(format!("--version-range=1.{toolchain}..=1.{toolchain}"));
         }
     }
     cmd.args(args);

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -134,11 +134,14 @@ OPTIONS:
 
             This flag can only be used together with either --features or --include-features.
 
-        --version-range <START>..[END]
+        --version-range [START]..[=END]
             Perform commands on a specified (inclusive) range of Rust versions.
 
-            If the given range is unclosed, the latest stable compiler is treated as the upper
-            bound.
+            If the upper bound of the range is omitted, the latest stable compiler is used as the
+            upper bound.
+
+            If the lower bound of the range is omitted, the value of the `rust-version` field in
+            `Cargo.toml` is used as the lower bound.
 
             Note that ranges are always inclusive ranges.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -34,7 +34,7 @@ OPTIONS:
         --ignore-private                 Skip to perform on `publish = false` packages
         --ignore-unknown-features        Skip passing --features flag to `cargo` if that feature
                                          does not exist in the package
-        --version-range <START>..[END]   Perform commands on a specified (inclusive) range of Rust
+        --version-range [START]..[=END]  Perform commands on a specified (inclusive) range of Rust
                                          versions
         --version-step <NUM>             Specify the version interval of --version-range (default
                                          to `1`)


### PR DESCRIPTION
```
$ cargo hack check --version-range 1.63..1.64
warning: using `..` for inclusive range is deprecated; consider using `1.63..=1.64`
```

This also updates outdated help messages.

Closes #197
cc @epage