### PR TITLE
refactor: Move VersionRange parsing to CLI

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, format_err, Result};
 use crate::{version::Version, ProcessBuilder};
 
 // The version detection logic is based on https://github.com/cuviper/autocfg/blob/1.0.1/src/version.rs#L25-L59
-pub(crate) fn minor_version(mut cmd: ProcessBuilder<'_>) -> Result<u32> {
+pub(crate) fn version(mut cmd: ProcessBuilder<'_>) -> Result<Version> {
     cmd.args(["--version", "--verbose"]);
     let output = cmd.read()?;
 
@@ -23,5 +23,5 @@ pub(crate) fn minor_version(mut cmd: ProcessBuilder<'_>) -> Result<u32> {
         bail!("unexpected output from {cmd}: {output}");
     }
 
-    Ok(version.minor)
+    Ok(version)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -413,14 +413,6 @@ impl Args {
                 requires("--group-features", &["--feature-powerset"])?;
             }
         }
-        if version_range.is_none() {
-            if version_step.is_some() {
-                requires("--version-step", &["--version-range"])?;
-            }
-            if clean_per_version {
-                requires("--clean-per-version", &["--version-range"])?;
-            }
-        }
 
         let depth = depth.as_deref().map(str::parse::<usize>).transpose()?;
         let group_features = parse_grouped_features(&group_features, "group-features")?;
@@ -519,6 +511,13 @@ impl Args {
             let rustup = Rustup::new();
             if rustup.version < 23 {
                 bail!("--version-range requires rustup 1.23 or later");
+            }
+        } else {
+            if version_step.is_some() {
+                requires("--version-step", &["--version-range"])?;
+            }
+            if clean_per_version {
+                requires("--clean-per-version", &["--version-range"])?;
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use lexopt::{
     ValueExt,
 };
 
-use crate::{term, Feature, Rustup};
+use crate::{term, version::VersionRange, Feature, Rustup};
 
 pub(crate) struct Args {
     pub(crate) leading_args: Vec<String>,
@@ -52,7 +52,7 @@ pub(crate) struct Args {
     /// --print-command-list
     pub(crate) print_command_list: bool,
     /// --version-range
-    pub(crate) version_range: Option<String>,
+    pub(crate) version_range: Option<VersionRange>,
     /// --version-step
     pub(crate) version_step: Option<String>,
 
@@ -520,6 +520,7 @@ impl Args {
                 requires("--clean-per-version", &["--version-range"])?;
             }
         }
+        let version_range = version_range.map(|v| v.parse()).transpose()?;
 
         if no_dev_deps {
             info!(

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,7 +79,6 @@ impl Context {
         this.version_range = this
             .args
             .version_range
-            .as_ref()
             .map(|range| rustup::version_range(range, this.args.version_step.as_deref(), &this))
             .transpose()?;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,8 +41,9 @@ impl Context {
         );
 
         // If failed to determine cargo version, assign 0 to skip all version-dependent decisions.
-        let cargo_version = cargo::minor_version(cmd!(&cargo))
+        let cargo_version = cargo::version(cmd!(&cargo))
             .map_err(|e| warn!("unable to determine cargo version: {e:#}"))
+            .map(|v| v.minor)
             .unwrap_or(0);
 
         // if `--remove-dev-deps` flag is off, restore manifest file.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -52,7 +52,8 @@ impl Metadata {
         mut cargo_version: u32,
         restore: &restore::Manager,
     ) -> Result<Self> {
-        let stable_cargo_version = cargo::minor_version(cmd!("cargo", "+stable")).unwrap_or(0);
+        let stable_cargo_version =
+            cargo::version(cmd!("cargo", "+stable")).map(|v| v.minor).unwrap_or(0);
 
         let mut cmd;
         let json = if stable_cargo_version > cargo_version {

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -24,7 +24,7 @@ impl Rustup {
 }
 
 pub(crate) fn version_range(
-    range: &str,
+    range: VersionRange,
     step: Option<&str>,
     cx: &Context,
 ) -> Result<Vec<(u32, String)>> {
@@ -41,7 +41,7 @@ pub(crate) fn version_range(
         Ok(())
     };
 
-    let VersionRange { start_inclusive, end_inclusive } = range.parse()?;
+    let VersionRange { start_inclusive, end_inclusive } = range;
 
     let start_inclusive = match start_inclusive {
         Some(start) => start,

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -63,7 +63,7 @@ pub(crate) fn version_range(
     let end = match split.next() {
         Some("") | None => {
             install_toolchain("stable", &[], false)?;
-            cargo::minor_version(cmd!("cargo", "+stable"))?
+            cargo::version(cmd!("cargo", "+stable"))?
         }
         Some(end) => {
             let end = match end.strip_prefix('=') {
@@ -78,7 +78,7 @@ pub(crate) fn version_range(
             };
             let end = end.parse()?;
             check(&end)?;
-            end.minor
+            end
         }
     };
 
@@ -87,7 +87,7 @@ pub(crate) fn version_range(
         bail!("--version-step cannot be zero");
     }
 
-    let versions: Vec<_> = (start.minor..=end)
+    let versions: Vec<_> = (start.minor..=end.minor)
         .step_by(step as _)
         .map(|minor| (minor, format!("+1.{minor}")))
         .collect();

--- a/src/version.rs
+++ b/src/version.rs
@@ -19,3 +19,40 @@ impl FromStr for Version {
         Ok(Self { major, minor, patch })
     }
 }
+
+pub(crate) struct VersionRange {
+    pub(crate) start_inclusive: Option<Version>,
+    pub(crate) end_inclusive: Option<Version>,
+}
+
+impl FromStr for VersionRange {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (start, end_inclusive) = if let Some((start, end)) = s.split_once("..") {
+            let end = match end.strip_prefix('=') {
+                Some(end) => end,
+                None => {
+                    warn!(
+                        "using `..` for inclusive range is deprecated; consider using `{}`",
+                        s.replace("..", "..=")
+                    );
+                    end
+                }
+            };
+            (start, maybe_version(end)?)
+        } else {
+            (s, None)
+        };
+        let start_inclusive = maybe_version(start)?;
+        Ok(Self { start_inclusive, end_inclusive })
+    }
+}
+
+fn maybe_version(s: &str) -> Result<Option<Version>, Error> {
+    if s.is_empty() {
+        Ok(None)
+    } else {
+        s.parse().map(Some)
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,11 +1,24 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use anyhow::{Context as _, Error, Result};
 
+#[derive(Copy, Clone)]
 pub(crate) struct Version {
     pub(crate) major: u32,
     pub(crate) minor: u32,
     pub(crate) patch: Option<u32>,
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let major = self.major;
+        let minor = self.minor;
+        write!(f, "{major}.{minor}")?;
+        if let Some(patch) = self.patch {
+            write!(f, ".{patch}")?;
+        }
+        Ok(())
+    }
 }
 
 impl FromStr for Version {
@@ -20,9 +33,23 @@ impl FromStr for Version {
     }
 }
 
+#[derive(Copy, Clone)]
 pub(crate) struct VersionRange {
     pub(crate) start_inclusive: Option<Version>,
     pub(crate) end_inclusive: Option<Version>,
+}
+
+impl fmt::Display for VersionRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(start) = self.start_inclusive {
+            write!(f, "{start}")?;
+        }
+        write!(f, "..=")?;
+        if let Some(end) = self.end_inclusive {
+            write!(f, "{end}")?;
+        }
+        Ok(())
+    }
 }
 
 impl FromStr for VersionRange {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1418,7 +1418,7 @@ fn version_range_failure() {
     // empty
     cargo_hack(["check", "--version-range", "1.45..1.44"])
         .assert_failure("real")
-        .stderr_contains("specified version range `1.45..1.44` is empty");
+        .stderr_contains("specified version range `1.45..=1.44` is empty");
     cargo_hack(["check", "--version-range", "1.45..=1.44"])
         .assert_failure("real")
         .stderr_contains("specified version range `1.45..=1.44` is empty");


### PR DESCRIPTION
This is preparation for #196.  The plan for #196 is to make it so a `--rust-version` flag can set `rust_version` to a `RustVersion::msrv()` and it'll all just work.

For myself, I considered these commits sufficient enough to stand on their own even if something happens with #196 so I thought I'd post them separately which also allows them to be reviewed and merged while I continue on the rest of #196.

This includes multiple commits that each tells one small part of the story and I would recommend looking at this commit-by-commit,