### PR TITLE
Reject inclusive range without end expression

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1446,6 +1446,14 @@ fn version_range_failure() {
         .assert_failure("real")
         .stderr_contains("major version must be 1");
 
+    // inclusive range without end expression
+    cargo_hack(["check", "--version-range", "..="]).assert_failure("real").stderr_contains(
+        "inclusive range `..=` must have end expression; consider using `..` or `..=<end>`",
+    );
+    cargo_hack(["check", "--version-range", "1.45..="]).assert_failure("real").stderr_contains(
+        "inclusive range `1.45..=` must have end expression; consider using `1.45..` or `1.45..=<end>`",
+    );
+
     // patch version
     cargo_hack(["check", "--version-range", "1.45.2.."])
         .assert_failure("real") // warn


### PR DESCRIPTION
Inclusive range without end expression (`..=` and `<start>..=`) are strange, and rustc also rejects them ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=61df5736df9a693b31c9671b2c30a2c0)).

```
error[E0586]: inclusive range with no end
 --> src/main.rs:2:15
  |
2 |     for _ in 0..= {
  |               ^^^ help: use `..` instead
  |
  = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
```

```console
$ cargo hack check --version-range 1.45..=
error: inclusive range `1.45..=` must have end expression; consider using `1.45..` or `1.45..=<end>`
```