### PR TITLE
Use `rustup run <toolchain>` instead of `cargo +<toolchain>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,11 +316,13 @@ Perform commands on a specified (inclusive) range of Rust versions.
 
 ```console
 $ cargo hack check --version-range 1.46..=1.47
-info: running `cargo +1.46 check` on cargo-hack (1/2)
+info: running `rustup run 1.46 cargo check` on cargo-hack (1/2)
 ...
-info: running `cargo +1.47 check` on cargo-hack (2/2)
+info: running `rustup run 1.47 cargo check` on cargo-hack (2/2)
 ...
 ```
+
+(We use `rustup run <toolchain> cargo` instead of `cargo +<toolchain>` to work around a [rustup bug](https://github.com/rust-lang/rustup/issues/3036).)
 
 This might be useful for catching issues like [termcolor#35], [regex#685],
 [rust-clippy#6324].

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -53,7 +53,7 @@ impl Metadata {
         restore: &restore::Manager,
     ) -> Result<Self> {
         let stable_cargo_version =
-            cargo::version(cmd!("cargo", "+stable")).map(|v| v.minor).unwrap_or(0);
+            cargo::version(cmd!("rustup", "run", "stable", "cargo")).map(|v| v.minor).unwrap_or(0);
 
         let mut cmd;
         let json = if stable_cargo_version > cargo_version {
@@ -79,7 +79,7 @@ impl Metadata {
             // Try with stable cargo because if workspace member has
             // a dependency that requires newer cargo features, `cargo metadata`
             // with older cargo may fail.
-            cmd = cmd!("cargo", "+stable", "metadata", "--format-version=1");
+            cmd = cmd!("rustup", "run", "stable", "cargo", "metadata", "--format-version=1");
             if let Some(manifest_path) = &args.manifest_path {
                 cmd.arg("--manifest-path");
                 cmd.arg(manifest_path);

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -43,7 +43,7 @@ pub(crate) fn version_range(range: VersionRange, cx: &Context) -> Result<Vec<u32
             Ok(stable_version)
         } else {
             install_toolchain("stable", &[], false)?;
-            let version = cargo::version(cmd!("cargo", "+stable"))?;
+            let version = cargo::version(cmd!("rustup", "run", "stable", "cargo"))?;
             stable_version = Some(version);
             Ok(version)
         }
@@ -114,7 +114,7 @@ pub(crate) fn install_toolchain(
     toolchain = toolchain.strip_prefix('+').unwrap_or(toolchain);
 
     if target.is_empty()
-        && cmd!("cargo", format!("+{toolchain}"), "--version").run_with_output().is_ok()
+        && cmd!("rustup", "run", toolchain, "cargo", "--version").run_with_output().is_ok()
     {
         // Do not run `rustup toolchain add` if the toolchain already has installed.
         return Ok(());

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    env::{self, consts::EXE_SUFFIX},
+    env,
     ffi::OsStr,
     path::{Path, PathBuf},
     process::{Command, ExitStatus},
@@ -24,14 +24,6 @@ pub fn cargo_bin_exe() -> Command {
     cmd.env_remove("CARGO_TERM_COLOR");
     cmd.env_remove("GITHUB_ACTIONS");
     cmd
-}
-
-fn test_toolchain() -> String {
-    if let Some(toolchain) = test_version() {
-        format!("+1.{toolchain} ")
-    } else {
-        String::new()
-    }
 }
 
 fn test_version() -> Option<u32> {
@@ -145,10 +137,12 @@ struct AssertOutputInner {
 }
 
 fn replace_command(lines: &str) -> String {
-    if lines.contains("cargo +") || lines.contains(&format!("cargo{EXE_SUFFIX} +")) {
+    if lines.contains("rustup run") {
         lines.to_owned()
+    } else if let Some(minor) = test_version() {
+        lines.replace("cargo ", &format!("rustup run 1.{minor} cargo "))
     } else {
-        lines.replace("cargo ", &format!("cargo {}", test_toolchain()))
+        lines.to_owned()
     }
 }
 fn line_separated(lines: &str) -> impl Iterator<Item = &'_ str> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1315,13 +1315,12 @@ fn default_feature_behavior() {
         .stdout_not_contains("has default feature!");
 }
 
-#[cfg_attr(windows, ignore)] // rustup bug: https://github.com/rust-lang/rustup/issues/3036
 #[test]
 fn version_range() {
     cargo_hack(["check", "--version-range", "1.63..=1.64"]).assert_success("real").stderr_contains(
         "
-        running `cargo +1.63 check` on real (1/2)
-        running `cargo +1.64 check` on real (2/2)
+        running `rustup run 1.63 cargo check` on real (1/2)
+        running `rustup run 1.64 cargo check` on real (2/2)
         ",
     );
 
@@ -1330,8 +1329,8 @@ fn version_range() {
         .stderr_contains(
             "
             warning: using `..` for inclusive range is deprecated; consider using `1.63..=1.64`
-            running `cargo +1.63 check` on real (1/2)
-            running `cargo +1.64 check` on real (2/2)
+            running `rustup run 1.63 cargo check` on real (1/2)
+            running `rustup run 1.64 cargo check` on real (2/2)
             ",
         );
 
@@ -1339,8 +1338,8 @@ fn version_range() {
         .assert_success("real")
         .stderr_contains(format!(
             "
-            running `cargo +1.63 check --target {TARGET}` on real (1/2)
-            running `cargo +1.64 check --target {TARGET}` on real (2/2)
+            running `rustup run 1.63 cargo check --target {TARGET}` on real (1/2)
+            running `rustup run 1.64 cargo check --target {TARGET}` on real (2/2)
             ",
         ));
 
@@ -1348,31 +1347,23 @@ fn version_range() {
         .assert_success("rust-version")
         .stderr_contains(
             "
-            running `cargo +1.64 check` on real (1/1)
+            running `rustup run 1.64 cargo check` on real (1/1)
             ",
         );
 }
 
-#[cfg_attr(windows, ignore)] // rustup bug: https://github.com/rust-lang/rustup/issues/3036
 #[test]
 fn rust_version() {
     cargo_hack(["check", "--rust-version"]).assert_success("rust-version").stderr_contains(
         "
-            running `cargo +1.64 check` on real (1/1)
-            ",
+        running `rustup run 1.64 cargo check` on real (1/1)
+        ",
     );
 }
 
-#[cfg_attr(windows, ignore)] // rustup bug: https://github.com/rust-lang/rustup/issues/3036
 #[test]
 fn multi_target() {
-    let target_suffix = if cfg!(target_os = "linux") && cfg!(target_env = "gnu") {
-        "-unknown-linux-gnu"
-    } else if cfg!(target_os = "macos") {
-        "-apple-darwin"
-    } else {
-        unimplemented!()
-    };
+    let target_suffix = String::from("-") + TARGET.split_once('-').unwrap().1;
 
     cargo_hack([
         "check",
@@ -1384,8 +1375,8 @@ fn multi_target() {
     .assert_success("real")
     .stderr_contains(format!(
         "
-        running `cargo +1.63 check --target aarch64{target_suffix}` on real (1/2)
-        running `cargo +1.64 check --target aarch64{target_suffix}` on real (2/2)
+        running `rustup run 1.63 cargo check --target aarch64{target_suffix}` on real (1/2)
+        running `rustup run 1.64 cargo check --target aarch64{target_suffix}` on real (2/2)
         "
     ));
 
@@ -1401,9 +1392,9 @@ fn multi_target() {
     .assert_success("real")
     .stderr_contains(format!(
         "
-        running `cargo +1.63 check --target aarch64{target_suffix}` on real (1/3)
-        running `cargo +1.63 check --target x86_64{target_suffix}` on real (2/3)
-        running `cargo +1.64 check --target aarch64{target_suffix} --target x86_64{target_suffix}` on real (3/3)
+        running `rustup run 1.63 cargo check --target aarch64{target_suffix}` on real (1/3)
+        running `rustup run 1.63 cargo check --target x86_64{target_suffix}` on real (2/3)
+        running `rustup run 1.64 cargo check --target aarch64{target_suffix} --target x86_64{target_suffix}` on real (3/3)
         ",
     ));
 
@@ -1419,13 +1410,12 @@ fn multi_target() {
     .assert_success("real")
     .stderr_contains(format!(
         "
-        running `cargo +1.63 check --target x86_64{target_suffix}` on real (1/2)
-        running `cargo +1.64 check --target x86_64{target_suffix}` on real (2/2)
+        running `rustup run 1.63 cargo check --target x86_64{target_suffix}` on real (1/2)
+        running `rustup run 1.64 cargo check --target x86_64{target_suffix}` on real (2/2)
         ",
     ));
 }
 
-#[cfg_attr(windows, ignore)] // rustup bug: https://github.com/rust-lang/rustup/issues/3036
 #[test]
 fn version_range_failure() {
     // zero step


### PR DESCRIPTION
Work around a rustup bug ([rust-lang/rustup#3036](https://github.com/rust-lang/rustup/issues/3036)) on Windows. (Unfortunately, the problem still exists if a workaround is not used: https://github.com/taiki-e/cargo-hack/actions/runs/6111021546/job/16585330408)

I had already addressed this in my other project about a year ago (https://github.com/taiki-e/cargo-minimal-versions/commit/84848e392e8208e6d87426dc798d867a6b69de3a), but in this project it was delayed for a long time because the mechanism for testing compatibility with the old Cargo was a bit complicated.