### PR TITLE
refactor: Defer calculating the toolchain flag

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,7 @@ pub(crate) struct Context {
     pub(crate) cargo_version: u32,
     pub(crate) restore: restore::Manager,
     pub(crate) current_dir: PathBuf,
-    pub(crate) version_range: Option<Vec<(u32, String)>>,
+    pub(crate) version_range: Option<Vec<u32>>,
     pub(crate) use_github_action_grouping: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn try_main() -> Result<()> {
         if let Some(range) = &cx.version_range {
             let total = progress.total;
             progress.total = 0;
-            for (cargo_version, _) in range {
+            for cargo_version in range {
                 if cx.target.is_empty() || *cargo_version >= 64 {
                     progress.total += total;
                 } else {
@@ -79,11 +79,12 @@ fn try_main() -> Result<()> {
             // Workaround for spurious "failed to select a version" error.
             // (This does not work around the underlying cargo bug: https://github.com/rust-lang/cargo/issues/10623)
             let mut regenerate_lockfile_on_51_or_up = false;
-            for (cargo_version, toolchain) in range {
-                rustup::install_toolchain(toolchain, &cx.target, true)?;
+            for cargo_version in range {
+                let toolchain = format!("+1.{cargo_version}");
+                rustup::install_toolchain(&toolchain, &cx.target, true)?;
                 if generate_lockfile || regenerate_lockfile_on_51_or_up && *cargo_version >= 51 {
                     let mut line = line.clone();
-                    line.leading_arg(toolchain);
+                    line.leading_arg(&toolchain);
                     line.arg("generate-lockfile");
                     if let Some(pid) = cx.current_package() {
                         let package = cx.packages(pid);
@@ -110,7 +111,7 @@ fn try_main() -> Result<()> {
                 }
 
                 let mut line = line.clone();
-                line.leading_arg(toolchain);
+                line.leading_arg(&toolchain);
                 line.apply_context(cx);
                 exec_on_packages(
                     cx,

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -23,7 +23,7 @@ impl Rustup {
     }
 }
 
-pub(crate) fn version_range(range: VersionRange, cx: &Context) -> Result<Vec<(u32, String)>> {
+pub(crate) fn version_range(range: VersionRange, cx: &Context) -> Result<Vec<u32>> {
     let check = |version: &Version| {
         if version.major != 1 {
             bail!("major version must be 1");
@@ -98,10 +98,8 @@ pub(crate) fn version_range(range: VersionRange, cx: &Context) -> Result<Vec<(u3
         MaybeVersion::Stable => get_stable_version()?,
     };
 
-    let versions: Vec<_> = (start_inclusive.minor..=end_inclusive.minor)
-        .step_by(cx.version_step as _)
-        .map(|minor| (minor, format!("+1.{minor}")))
-        .collect();
+    let versions: Vec<_> =
+        (start_inclusive.minor..=end_inclusive.minor).step_by(cx.version_step as _).collect();
     if versions.is_empty() {
         bail!("specified version range `{range}` is empty");
     }


### PR DESCRIPTION
In addition to decoupling concerns (expansion of a range into discrete versions), this will make it easier to do contains checks and insertions on the discrete versions.