### PR TITLE
fix: Select MSRV based on selected packages

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -15,7 +15,7 @@ use crate::{
     features::Features,
     manifest::Manifest,
     metadata::{Metadata, Package, PackageId},
-    restore, rustup, term, ProcessBuilder,
+    restore, term, ProcessBuilder,
 };
 
 pub(crate) struct Context {
@@ -27,7 +27,6 @@ pub(crate) struct Context {
     pub(crate) cargo_version: u32,
     pub(crate) restore: restore::Manager,
     pub(crate) current_dir: PathBuf,
-    pub(crate) version_range: Option<Vec<u32>>,
     pub(crate) use_github_action_grouping: bool,
 }
 
@@ -65,7 +64,7 @@ impl Context {
             pkg_features.insert(id.clone(), features);
         }
 
-        let mut this = Self {
+        let this = Self {
             args,
             metadata,
             manifests,
@@ -74,13 +73,9 @@ impl Context {
             cargo_version,
             restore,
             current_dir: env::current_dir()?,
-            version_range: None,
             // TODO: should be optional?
             use_github_action_grouping: env::var_os("GITHUB_ACTIONS").is_some(),
         };
-
-        this.version_range =
-            this.args.version_range.map(|range| rustup::version_range(range, &this)).transpose()?;
 
         // TODO: Ideally, we should do this, but for now, we allow it as cargo-hack
         // may mistakenly interpret the specified valid feature flag as unknown.

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,11 +60,14 @@ fn try_main() -> Result<()> {
 
         let mut progress = Progress::default();
         let packages = determine_package_list(cx, &mut progress)?;
+
         let mut keep_going = KeepGoing::default();
-        if let Some(range) = &cx.version_range {
+        if let Some(range) = cx.version_range {
+            let range = rustup::version_range(range, cx.version_step, cx)?;
+
             let total = progress.total;
             progress.total = 0;
-            for cargo_version in range {
+            for cargo_version in &range {
                 if cx.target.is_empty() || *cargo_version >= 64 {
                     progress.total += total;
                 } else {
@@ -81,7 +84,7 @@ fn try_main() -> Result<()> {
             // Workaround for spurious "failed to select a version" error.
             // (This does not work around the underlying cargo bug: https://github.com/rust-lang/cargo/issues/10623)
             let mut regenerate_lockfile_on_51_or_up = false;
-            for cargo_version in range {
+            for cargo_version in &range {
                 let toolchain = format!("1.{cargo_version}");
                 rustup::install_toolchain(&toolchain, &cx.target, true)?;
                 if generate_lockfile || regenerate_lockfile_on_51_or_up && *cargo_version >= 51 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn try_main() -> Result<()> {
 
         let mut keep_going = KeepGoing::default();
         if let Some(range) = cx.version_range {
-            let range = rustup::version_range(range, cx.version_step, cx)?;
+            let range = rustup::version_range(range, cx.version_step, &packages, cx)?;
 
             let total = progress.total;
             progress.total = 0;

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -23,7 +23,7 @@ impl Rustup {
     }
 }
 
-pub(crate) fn version_range(range: VersionRange, cx: &Context) -> Result<Vec<u32>> {
+pub(crate) fn version_range(range: VersionRange, step: u16, cx: &Context) -> Result<Vec<u32>> {
     let check = |version: &Version| {
         if version.major != 1 {
             bail!("major version must be 1");
@@ -99,7 +99,7 @@ pub(crate) fn version_range(range: VersionRange, cx: &Context) -> Result<Vec<u32
     };
 
     let versions: Vec<_> =
-        (start_inclusive.minor..=end_inclusive.minor).step_by(cx.version_step as _).collect();
+        (start_inclusive.minor..=end_inclusive.minor).step_by(step as _).collect();
     if versions.is_empty() {
         bail!("specified version range `{range}` is empty");
     }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -5,7 +5,9 @@ use anyhow::{bail, format_err, Result};
 use crate::{
     cargo,
     context::Context,
+    metadata::PackageId,
     version::{MaybeVersion, Version, VersionRange},
+    Kind,
 };
 
 pub(crate) struct Rustup {
@@ -23,7 +25,12 @@ impl Rustup {
     }
 }
 
-pub(crate) fn version_range(range: VersionRange, step: u16, cx: &Context) -> Result<Vec<u32>> {
+pub(crate) fn version_range(
+    range: VersionRange,
+    step: u16,
+    packages: &[(&PackageId, Kind<'_>)],
+    cx: &Context,
+) -> Result<Vec<u32>> {
     let check = |version: &Version| {
         if version.major != 1 {
             bail!("major version must be 1");
@@ -55,7 +62,7 @@ pub(crate) fn version_range(range: VersionRange, step: u16, cx: &Context) -> Res
             Ok(rust_version)
         } else {
             let mut version = None;
-            for id in cx.workspace_members() {
+            for (id, _) in packages {
                 let v = cx.rust_version(id);
                 if v.is_none() || v == version {
                     // no-op

--- a/tests/fixtures/rust-version/Cargo.toml
+++ b/tests/fixtures/rust-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "real"
 version = "0.0.0"
 publish = false
-rust-version = "1.64"
+rust-version = "1.65"
 
 [workspace]
 members = [

--- a/tests/fixtures/rust-version/member1/Cargo.toml
+++ b/tests/fixtures/rust-version/member1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "member1"
 version = "0.0.0"
-rust-version = "1.64"
+rust-version = "1.63"
 
 [features]
 default = []

--- a/tests/fixtures/rust-version/member2/Cargo.toml
+++ b/tests/fixtures/rust-version/member2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "member2"
 version = "0.0.0"
 publish = false
-rust-version = "1.64"
+rust-version = "1.63"
 
 [features]
 default = []

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1343,7 +1343,17 @@ fn version_range() {
             ",
         ));
 
-    cargo_hack(["check", "--version-range", "..=1.64"])
+    cargo_hack(["check", "--version-range", "..=1.64", "--package=member1", "--package=member2"])
+        .assert_success("rust-version")
+        .stderr_contains(
+            "
+            running `rustup run 1.63 cargo check` on member1 (1/4)
+            running `rustup run 1.63 cargo check` on member2 (2/4)
+            running `rustup run 1.64 cargo check` on member1 (3/4)
+            running `rustup run 1.64 cargo check` on member2 (4/4)
+            ",
+        );
+    cargo_hack(["check", "--version-range", "..=1.64", "--workspace"])
         .assert_failure("rust-version")
         .stderr_contains(
             "
@@ -1354,7 +1364,15 @@ fn version_range() {
 
 #[test]
 fn rust_version() {
-    cargo_hack(["check", "--rust-version"])
+    cargo_hack(["check", "--rust-version", "--package=member1", "--package=member2"])
+        .assert_success("rust-version")
+        .stderr_contains(
+            "
+            running `rustup run 1.63 cargo check` on member1 (1/2)
+            running `rustup run 1.63 cargo check` on member2 (2/2)
+            ",
+        );
+    cargo_hack(["check", "--rust-version", "--workspace"])
         .assert_failure("rust-version")
         .stderr_contains(
             "

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1344,21 +1344,23 @@ fn version_range() {
         ));
 
     cargo_hack(["check", "--version-range", "..=1.64"])
-        .assert_success("rust-version")
+        .assert_failure("rust-version")
         .stderr_contains(
             "
-            running `rustup run 1.64 cargo check` on real (1/1)
+            automatic detection of the lower bound of the version range is not yet supported when the minimum supported Rust version of the crates in the workspace do not match
             ",
         );
 }
 
 #[test]
 fn rust_version() {
-    cargo_hack(["check", "--rust-version"]).assert_success("rust-version").stderr_contains(
-        "
-        running `rustup run 1.64 cargo check` on real (1/1)
-        ",
-    );
+    cargo_hack(["check", "--rust-version"])
+        .assert_failure("rust-version")
+        .stderr_contains(
+            "
+            automatic detection of the lower bound of the version range is not yet supported when the minimum supported Rust version of the crates in the workspace do not match
+            ",
+        );
 }
 
 #[test]


### PR DESCRIPTION
Currently, cargo-hack calculates the MSRV based on all packages and if they disagree, it errors.  While we want to make the MSRV calculation to be per-package, this is an intermediate step wards that by at least making it so cargo-hack won't error if the selected set of packages agree on an MSRV.

To allow the selected packages to be used in the expansion of a range into versions, the range expansion code was pulled out of the Context.

For testing this, I made the `rust-version` fixture have multiple versions and the tests show that this works while also failing in some cases.  The failure is not in a `_failure` test because the intention is to get that case working in a follow up PR.