### PR TITLE
feat: Support multiple MSRVs with --rust-version 

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -2,11 +2,18 @@ use std::{fmt, str::FromStr};
 
 use anyhow::{bail, Context as _, Error, Result};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct Version {
     pub(crate) major: u32,
     pub(crate) minor: u32,
     pub(crate) patch: Option<u32>,
+}
+
+impl Version {
+    pub(crate) fn strip_patch(mut self) -> Self {
+        self.patch = None;
+        self
+    }
 }
 
 impl fmt::Display for Version {
@@ -33,14 +40,14 @@ impl FromStr for Version {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum MaybeVersion {
     Version(Version),
     Msrv,
     Stable,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) struct VersionRange {
     pub(crate) start_inclusive: MaybeVersion,
     pub(crate) end_inclusive: MaybeVersion,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1373,10 +1373,13 @@ fn rust_version() {
             ",
         );
     cargo_hack(["check", "--rust-version", "--workspace"])
-        .assert_failure("rust-version")
+        .assert_success("rust-version")
         .stderr_contains(
             "
-            automatic detection of the lower bound of the version range is not yet supported when the minimum supported Rust version of the crates in the workspace do not match
+            running `rustup run 1.63 cargo check` on member1 (1/4)
+            running `rustup run 1.63 cargo check` on member2 (2/4)
+            running `rustup run 1.64 cargo check` on member3 (3/4)
+            running `rustup run 1.65 cargo check` on real (4/4)
             ",
         );
 }


### PR DESCRIPTION
This creates a special case for `--rust-version` to handle multiple MSRVs and ignores `--version-range`.
This is a part of https://github.com/taiki-e/cargo-hack/issues/199, covering the simplest but likely most needed subset (at least needed by cargo).