### PR TITLE
feat: Support mixed MSRV in --version-range 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,13 +64,12 @@ fn try_main() -> Result<()> {
 
         let packages = determine_package_list(cx)?;
         let mut progress = Progress::default();
-        for pkg in &packages {
-            progress.total += pkg.feature_count;
-        }
-
         let mut keep_going = KeepGoing::default();
         if let Some(range) = cx.version_range {
             if range == VersionRange::msrv() {
+                let total = packages.iter().map(|p| p.feature_count).sum();
+                progress.total = total;
+
                 let mut versions = BTreeMap::new();
                 for pkg in packages {
                     let v = cx
@@ -103,8 +102,7 @@ fn try_main() -> Result<()> {
             } else {
                 let range = rustup::version_range(range, cx.version_step, &packages, cx)?;
 
-                let total = progress.total;
-                progress.total = 0;
+                let total: usize = packages.iter().map(|p| p.feature_count).sum();
                 for cargo_version in &range {
                     if cx.target.is_empty() || *cargo_version >= 64 {
                         progress.total += total;
@@ -132,6 +130,8 @@ fn try_main() -> Result<()> {
                 }
             }
         } else {
+            let total = packages.iter().map(|p| p.feature_count).sum();
+            progress.total = total;
             default_cargo_exec_on_packages(cx, &packages, &mut progress, &mut keep_going)?;
         }
         if keep_going.count > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn try_main() -> Result<()> {
 
                 let total: usize = packages.iter().map(|p| p.feature_count).sum();
                 for cargo_version in &range {
-                    if cx.target.is_empty() || *cargo_version >= 64 {
+                    if cx.target.is_empty() || cargo_version.minor >= 64 {
                         progress.total += total;
                     } else {
                         progress.total += total * cx.target.len();
@@ -121,7 +121,7 @@ fn try_main() -> Result<()> {
                     versioned_cargo_exec_on_packages(
                         cx,
                         &packages,
-                        cargo_version,
+                        cargo_version.minor,
                         &mut progress,
                         &mut keep_going,
                         &mut generate_lockfile,

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -29,7 +29,7 @@ pub(crate) fn version_range(
     step: u16,
     packages: &[PackageRuns<'_>],
     cx: &Context,
-) -> Result<Vec<u32>> {
+) -> Result<Vec<Version>> {
     let check = |version: &Version| {
         if version.major != 1 {
             bail!("major version must be 1");
@@ -104,8 +104,10 @@ pub(crate) fn version_range(
         MaybeVersion::Stable => get_stable_version()?,
     };
 
-    let versions: Vec<_> =
-        (start_inclusive.minor..=end_inclusive.minor).step_by(step as _).collect();
+    let versions: Vec<_> = (start_inclusive.minor..=end_inclusive.minor)
+        .step_by(step as _)
+        .map(|minor| Version { major: 1, minor, patch: None })
+        .collect();
     if versions.is_empty() {
         bail!("specified version range `{range}` is empty");
     }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -5,9 +5,8 @@ use anyhow::{bail, format_err, Result};
 use crate::{
     cargo,
     context::Context,
-    metadata::PackageId,
     version::{MaybeVersion, Version, VersionRange},
-    Kind,
+    PackageRuns,
 };
 
 pub(crate) struct Rustup {
@@ -28,7 +27,7 @@ impl Rustup {
 pub(crate) fn version_range(
     range: VersionRange,
     step: u16,
-    packages: &[(&PackageId, Kind<'_>)],
+    packages: &[PackageRuns<'_>],
     cx: &Context,
 ) -> Result<Vec<u32>> {
     let check = |version: &Version| {
@@ -62,8 +61,8 @@ pub(crate) fn version_range(
             Ok(rust_version)
         } else {
             let mut version = None;
-            for (id, _) in packages {
-                let v = cx.rust_version(id);
+            for pkg in packages {
+                let v = cx.rust_version(pkg.id);
                 if v.is_none() || v == version {
                     // no-op
                 } else if version.is_none() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1353,11 +1353,30 @@ fn version_range() {
             running `rustup run 1.64 cargo check` on member2 (4/4)
             ",
         );
+    // Skips `real` because it isn't in range
     cargo_hack(["check", "--version-range", "..=1.64", "--workspace"])
-        .assert_failure("rust-version")
+        .assert_failure("rust-version") // warn
         .stderr_contains(
             "
-            automatic detection of the lower bound of the version range is not yet supported when the minimum supported Rust version of the crates in the workspace do not match
+            warning: skipping real, rust-version (1.65) is not in specified range (..=1.64)
+            running `rustup run 1.63 cargo check` on member1 (1/5)
+            running `rustup run 1.63 cargo check` on member2 (2/5)
+            running `rustup run 1.64 cargo check` on member1 (3/5)
+            running `rustup run 1.64 cargo check` on member2 (4/5)
+            running `rustup run 1.64 cargo check` on member3 (5/5)
+            ",
+        );
+    cargo_hack(["check", "--version-range", "..=1.66", "--version-step", "2", "--workspace"])
+        .assert_success("rust-version")
+        .stderr_contains(
+            "
+            running `rustup run 1.63 cargo check` on member1 (1/7)
+            running `rustup run 1.63 cargo check` on member2 (2/7)
+            running `rustup run 1.64 cargo check` on member3 (3/7)
+            running `rustup run 1.65 cargo check` on member1 (4/7)
+            running `rustup run 1.65 cargo check` on member2 (5/7)
+            running `rustup run 1.65 cargo check` on member3 (6/7)
+            running `rustup run 1.65 cargo check` on real (7/7)
             ",
         );
 }


### PR DESCRIPTION
This expands on the approach taken in #212 bucketing packages into
rust-versions to run.  If we skipped the MSRV (due to `--version-step`),
we automatically inject it.  If a package's MSRV isn't within the range,
we skip it.

Benefits
- Relatively simple to implement and to explain
- We keep the number of runs to a minimum by walking in lock-step the
  `--version-step`, independent of what each package' MSRV

I did have to specialize `--rust-version` vs `--version-range` to avoid
`--rust-version` range users walking more than they needed.

To keep the progress total accurate, I shifted the calculating of the
total from `determine_package_list` to after we have bucketed
everything.  To make this feasible, I saved off the how many iterations
a package will have without the version range being taken into account.

As a byproduct, this fixes a bug in #212 where it didn't take the
rust-version into account when determining the total.

Fixes #199