### PR TITLE
Add --log-group option to opt-out/force-enable log grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ OPTIONS:
         --keep-going
             Keep going on failure.
 
+        --log-group <KIND>
+            Log grouping: none, github-actions.
+
+            If this option is not used, the environment will be automatically detected.
+
         --print-command-list
             Print commands without run (Unstable).
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,6 @@ pub(crate) struct Context {
     pub(crate) cargo_version: u32,
     pub(crate) restore: restore::Manager,
     pub(crate) current_dir: PathBuf,
-    pub(crate) use_github_action_grouping: bool,
 }
 
 impl Context {
@@ -74,8 +73,6 @@ impl Context {
             cargo_version,
             restore,
             current_dir: env::current_dir()?,
-            // TODO: should be optional?
-            use_github_action_grouping: env::var_os("GITHUB_ACTIONS").is_some(),
         };
 
         // TODO: Ideally, we should do this, but for now, we allow it as cargo-hack

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -173,6 +173,11 @@ OPTIONS:
         --keep-going
             Keep going on failure.
 
+        --log-group <KIND>
+            Log grouping: none, github-actions.
+
+            If this option is not used, the environment will be automatically detected.
+
         --print-command-list
             Print commands without run (Unstable).
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -43,6 +43,7 @@ OPTIONS:
                                          command
         --clean-per-version              Remove artifacts per Rust version
         --keep-going                     Keep going on failure
+        --log-group <KIND>               Log grouping: none, github-actions
         --print-command-list             Print commands without run (Unstable)
         --no-manifest-path               Do not pass --manifest-path option to cargo (Unstable)
     -v, --verbose                        Use verbose output

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -300,6 +300,49 @@ fn exclude_failure() {
 }
 
 #[test]
+fn log_group() {
+    cargo_hack(["check", "--all", "--log-group", "none"])
+        .assert_success("virtual")
+        .stderr_contains(
+            "
+            running `cargo check` on member1
+            running `cargo check` on member2
+            ",
+        )
+        .stdout_not_contains(
+            "
+            ::endgroup::
+            ::group::
+            ",
+        )
+        .stderr_not_contains(
+            "
+            ::endgroup::
+            ::group::
+            ",
+        );
+
+    cargo_hack(["check", "--all", "--log-group", "github-actions"])
+        .assert_success("virtual")
+        .stdout_contains(
+            "
+            ::group::running `cargo check` on member1
+            ::endgroup::
+            ::group::running `cargo check` on member2
+            ::endgroup::
+            ",
+        )
+        .stderr_not_contains(
+            "
+            ::group::running `cargo check` on member1
+            ::endgroup::
+            ::group::running `cargo check` on member2
+            ::endgroup::
+            ",
+        );
+}
+
+#[test]
 fn no_dev_deps() {
     cargo_hack(["check", "--no-dev-deps"]).assert_success("real").stderr_contains(
         "


### PR DESCRIPTION
Follow-up to #206

```
        --log-group <KIND>
            Log grouping: none, github-actions.

            If this option is not used, the environment will be automatically detected.
```