### PR TITLE
ci: Test that cargo-hack works without rustup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,53 @@ jobs:
       - run: cargo hack build --workspace --no-private --feature-powerset --no-dev-deps
       - run: cargo minimal-versions build --workspace --no-private --all-features
 
+  test-compat:
+    name: test (1.${{ matrix.rust }})
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          # cargo-hack is usually runnable with Cargo versions older than the Rust version required for installation.
+          # When updating this, the reminder to update the minimum supported Rust version in README.md.
+          - 26
+          - 30
+          - 31
+          - 36
+          - 39
+          - 41
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup toolchain add nightly --no-self-update && rustup default nightly
+      - run: CARGO_HACK_TEST_TOOLCHAIN=${{ matrix.rust }} cargo test --workspace --all-features
+      # Remove stable toolchain to disable https://github.com/taiki-e/cargo-hack/pull/138's behavior.
+      - run: rustup toolchain remove stable
+      - run: CARGO_HACK_TEST_TOOLCHAIN=${{ matrix.rust }} cargo test --workspace --all-features
+
+  test-no-rustup:
+    name: test (no rustup)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container: alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: apk --no-cache add bash cargo
+        shell: sh
+      - run: cargo test --workspace --all-features
+      - run: |
+          set -euxo pipefail
+          cargo install --path . --debug
+          cd tests/fixtures/real
+          cargo hack check --feature-powerset --workspace
+          cargo uninstall cargo-hack
+
   build:
     name: build (${{ matrix.target }})
     strategy:
@@ -116,33 +163,6 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: target/${{ matrix.target }}/release/cargo-hack*
-
-  test-compat:
-    name: test (1.${{ matrix.rust }})
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          # cargo-hack is usually runnable with Cargo versions older than the Rust version required for installation.
-          # When updating this, the reminder to update the minimum supported Rust version in README.md.
-          - 26
-          - 30
-          - 31
-          - 36
-          - 39
-          - 41
-    runs-on: ubuntu-20.04
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Install Rust
-        run: rustup toolchain add nightly --no-self-update && rustup default nightly
-      - run: CARGO_HACK_TEST_TOOLCHAIN=${{ matrix.rust }} cargo test --workspace --all-features
-      # Remove stable toolchain to disable https://github.com/taiki-e/cargo-hack/pull/138's behavior.
-      - run: rustup toolchain remove stable
-      - run: CARGO_HACK_TEST_TOOLCHAIN=${{ matrix.rust }} cargo test --workspace --all-features
 
   miri:
     runs-on: ubuntu-latest

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -15,10 +15,12 @@ pub(crate) struct Rustup {
 
 impl Rustup {
     pub(crate) fn new() -> Self {
-        // If failed to determine rustup version, assign 0 to skip all version-dependent decisions.
+        // If failed to determine rustup version, assume the latest version.
         let version = minor_version()
-            .map_err(|e| warn!("unable to determine rustup version: {e:#}"))
-            .unwrap_or(0);
+            .map_err(|e| {
+                warn!("unable to determine rustup version; assuming latest stable rustup: {e:#}");
+            })
+            .unwrap_or(u32::MAX);
 
         Self { version }
     }

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -26,6 +26,10 @@ pub fn cargo_bin_exe() -> Command {
     cmd
 }
 
+pub fn has_rustup() -> bool {
+    Command::new("rustup").arg("--version").output().is_ok()
+}
+
 fn test_version() -> Option<u32> {
     static TEST_VERSION: OnceLock<Option<u32>> = OnceLock::new();
     *TEST_VERSION.get_or_init(|| {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,7 +8,7 @@ use std::{
     path::MAIN_SEPARATOR,
 };
 
-use auxiliary::{cargo_bin_exe, cargo_hack, has_stable_toolchain, CommandExt, TARGET};
+use auxiliary::{cargo_bin_exe, cargo_hack, has_rustup, has_stable_toolchain, CommandExt, TARGET};
 
 #[test]
 fn failures() {
@@ -1402,6 +1402,11 @@ fn default_feature_behavior() {
 
 #[test]
 fn version_range() {
+    // --version-range requires rustup
+    if !has_rustup() {
+        return;
+    }
+
     cargo_hack(["check", "--version-range", "1.63..=1.64"]).assert_success("real").stderr_contains(
         "
         running `rustup run 1.63 cargo check` on real (1/2)
@@ -1468,6 +1473,11 @@ fn version_range() {
 
 #[test]
 fn rust_version() {
+    // --rust-version requires rustup
+    if !has_rustup() {
+        return;
+    }
+
     cargo_hack(["check", "--rust-version", "--package=member1", "--package=member2"])
         .assert_success("rust-version")
         .stderr_contains(
@@ -1490,6 +1500,11 @@ fn rust_version() {
 
 #[test]
 fn multi_target() {
+    // --version-range requires rustup
+    if !has_rustup() {
+        return;
+    }
+
     let target_suffix = String::from("-") + TARGET.split_once('-').unwrap().1;
 
     cargo_hack([


### PR DESCRIPTION
Except for --version-range and --rust-version, cargo-hack works without rustup.