### PR TITLE
Improve error message when no rust-version field is specified

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,10 @@ fn try_main() -> Result<()> {
                     .map(Version::strip_patch);
                 if range == VersionRange::msrv() {
                     let msrv = msrv.ok_or_else(|| {
-                        format_err!("no rust-version field in Cargo.toml is specified")
+                        format_err!(
+                            "no rust-version field in {}'s Cargo.toml is specified",
+                            cx.packages(pkg.id).name
+                        )
                     })?;
                     versions.entry(msrv).or_insert_with(Vec::new).push(pkg);
                 } else {

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -82,7 +82,7 @@ pub(crate) fn version_range(
                 };
             }
             let Some(lowest_msrv) = lowest_msrv else {
-                bail!("no rust-version field in Cargo.toml is specified")
+                bail!("no rust-version field in selected Cargo.toml's is specified")
             };
             rust_version = Some(lowest_msrv);
             Ok(lowest_msrv)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1598,7 +1598,8 @@ fn version_range_failure() {
 
     // No rust-version
     cargo_hack(["check", "--version-range", "..=1.64"]).assert_failure("real").stderr_contains(
-        "no rust-version field in Cargo.toml is specified
+        "
+        no rust-version field in selected Cargo.toml's is specified
         ",
     );
 }


### PR DESCRIPTION

Make error messages easier to understand in cases like https://github.com/rust-lang/cargo/actions/runs/6147097200/job/16677799392?pr=12654.

FYI @epage 