### PR TITLE
Add `--mutually-exclusive-features`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --mutually-exclusive-features <FEATURES>...
+            Space or comma separated list of features to not use together.
+
+            To specify multiple groups, use this option multiple times:
+            `--mutually-exclusive-features a,b --mutually-exclusive-features c,d`
+
+            This flag can only be used together with --feature-powerset flag.
+
         --at-least-one-of <FEATURES>...
             Space or comma separated list of features. Skips sets of features that don't enable any
             of the features listed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,8 +241,13 @@ fn determine_kind<'a>(
             Some(PackageRuns { id, kind, feature_count })
         }
     } else if cx.feature_powerset {
-        let features =
-            features::feature_powerset(features, cx.depth, &cx.at_least_one_of, &package.features);
+        let features = features::feature_powerset(
+            features,
+            cx.depth,
+            &cx.at_least_one_of,
+            &cx.mutually_exclusive_features,
+            &package.features,
+        );
 
         if (pkg_features.normal().is_empty() && pkg_features.optional_deps().is_empty()
             || !cx.include_features.is_empty())

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -97,6 +97,14 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --mutually-exclusive-features <FEATURES>...
+            Space or comma separated list of features to not use together.
+
+            To specify multiple groups, use this option multiple times:
+            `--mutually-exclusive-features a,b --mutually-exclusive-features c,d`
+
+            This flag can only be used together with --feature-powerset flag.
+
         --at-least-one-of <FEATURES>...
             Space or comma separated list of features. Skips sets of features that don't enable any
             of the features listed.

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -23,6 +23,8 @@ OPTIONS:
         --depth <NUM>                    Specify a max number of simultaneous feature flags of
                                          --feature-powerset
         --group-features <FEATURES>...   Space or comma separated list of features to group
+        --mutually-exclusive-features <FEATURES>... Space or comma separated list of features to not use
+                                         together
         --at-least-one-of <FEATURES>...  Space or comma separated list of features. Skips sets of
                                          features that don't enable any of the features listed
         --include-features <FEATURES>... Include only the specified features in the feature


### PR DESCRIPTION
The check for overlap between `--mutually-exclusive-features` and `--features` is not strictly necessary, as an overlap of a single item would be acceptable. There is currently no check for conflicting `--group-features` and `--mutually-exclusive-features`. If you would like this, let me know.

Closes #132