### PR TITLE
Run with --all-features first, run with biggest feature combination early (first or second) if --all-features case is skipped

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -586,11 +586,8 @@ impl Args {
 
         // https://github.com/taiki-e/cargo-hack/issues/42
         // https://github.com/rust-lang/cargo/pull/8799
-        let namespaced_features = has_z_flag(&cargo_args, "namespaced-features");
         exclude_no_default_features |= !include_features.is_empty();
-        exclude_all_features |= !include_features.is_empty()
-            || !exclude_features.is_empty()
-            || (feature_powerset && !namespaced_features && depth.is_none());
+        exclude_all_features |= !include_features.is_empty() || !exclude_features.is_empty();
         exclude_features.extend_from_slice(&features);
 
         term::verbose::set(verbose != 0);
@@ -666,25 +663,6 @@ fn parse_grouped_features(
             Ok(v)
         })?;
     Ok(group_features)
-}
-
-fn has_z_flag(args: &[String], name: &str) -> bool {
-    let mut iter = args.iter().map(String::as_str);
-    while let Some(mut arg) = iter.next() {
-        if arg == "-Z" {
-            arg = iter.next().unwrap();
-        } else if let Some(a) = arg.strip_prefix("-Z") {
-            arg = a;
-        } else {
-            continue;
-        }
-        if let Some(rest) = arg.strip_prefix(name) {
-            if rest.is_empty() || rest.starts_with('=') {
-                return true;
-            }
-        }
-    }
-    false
 }
 
 // (short flag, long flag, value name, short descriptions, additional descriptions)

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,6 +477,18 @@ fn exec_on_package(
         Kind::Each { .. } | Kind::Powerset { .. } => {}
     }
 
+    // Run with --all-features first: https://github.com/taiki-e/cargo-hack/issues/246
+    let pkg_features = cx.pkg_features(id);
+    if !cx.exclude_all_features
+        && pkg_features.normal().len() + pkg_features.optional_deps().len() > 1
+    {
+        let mut line = line.clone();
+        // run with all features
+        // https://github.com/taiki-e/cargo-hack/issues/42
+        line.arg("--all-features");
+        exec_cargo(cx, id, &mut line, progress, keep_going)?;
+    }
+
     if !cx.no_default_features {
         line.arg("--no-default-features");
     }
@@ -503,16 +515,6 @@ fn exec_on_package(
             }
         }
         Kind::Normal => unreachable!(),
-    }
-
-    let pkg_features = cx.pkg_features(id);
-    if !cx.exclude_all_features
-        && pkg_features.normal().len() + pkg_features.optional_deps().len() > 1
-    {
-        // run with all features
-        // https://github.com/taiki-e/cargo-hack/issues/42
-        line.arg("--all-features");
-        exec_cargo(cx, id, &mut line, progress, keep_going)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,6 +534,18 @@ fn exec_on_package(
             }
         }
         Kind::Powerset { features } => {
+            let features =
+                if exclude_all_features && features.len() > 1 && cx.depth.unwrap_or(usize::MAX) > 1
+                {
+                    // If --all-features case is skipped, run with the biggest feature combination early (first or second): https://github.com/taiki-e/cargo-hack/issues/246
+                    // TODO: The last combination is usually the biggest feature combination,
+                    // but in some cases this is not the case due to deduplication of the powerset.
+                    let last = features.last().unwrap();
+                    exec_cargo_with_features(cx, id, &line, progress, keep_going, last)?;
+                    &features[..features.len() - 1]
+                } else {
+                    features
+                };
             for f in features {
                 exec_cargo_with_features(cx, id, &line, progress, keep_going, f)?;
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -490,7 +490,7 @@ fn each_feature() {
             running `cargo check --no-default-features --features a,default` on real (5/5)
             ",
         )
-        .stderr_not_contains("--features a,a");
+        .stderr_not_contains("a,a");
 }
 
 #[test]
@@ -512,22 +512,23 @@ fn each_feature_failure() {
 fn feature_powerset() {
     cargo_hack(["check", "--feature-powerset"]).assert_success("real").stderr_contains(
         "
-        running `cargo check --no-default-features` on real (1/16)
-        running `cargo check --no-default-features --features a` on real (2/16)
-        running `cargo check --no-default-features --features b` on real (3/16)
-        running `cargo check --no-default-features --features a,b` on real (4/16)
-        running `cargo check --no-default-features --features c` on real (5/16)
-        running `cargo check --no-default-features --features a,c` on real (6/16)
-        running `cargo check --no-default-features --features b,c` on real (7/16)
-        running `cargo check --no-default-features --features a,b,c` on real (8/16)
-        running `cargo check --no-default-features --features default` on real (9/16)
-        running `cargo check --no-default-features --features a,default` on real (10/16)
-        running `cargo check --no-default-features --features b,default` on real (11/16)
-        running `cargo check --no-default-features --features a,b,default` on real (12/16)
-        running `cargo check --no-default-features --features c,default` on real (13/16)
-        running `cargo check --no-default-features --features a,c,default` on real (14/16)
-        running `cargo check --no-default-features --features b,c,default` on real (15/16)
-        running `cargo check --no-default-features --features a,b,c,default` on real (16/16)
+        running `cargo check --all-features` on real (1/17)
+        running `cargo check --no-default-features` on real (2/17)
+        running `cargo check --no-default-features --features a` on real (3/17)
+        running `cargo check --no-default-features --features b` on real (4/17)
+        running `cargo check --no-default-features --features a,b` on real (5/17)
+        running `cargo check --no-default-features --features c` on real (6/17)
+        running `cargo check --no-default-features --features a,c` on real (7/17)
+        running `cargo check --no-default-features --features b,c` on real (8/17)
+        running `cargo check --no-default-features --features a,b,c` on real (9/17)
+        running `cargo check --no-default-features --features default` on real (10/17)
+        running `cargo check --no-default-features --features a,default` on real (11/17)
+        running `cargo check --no-default-features --features b,default` on real (12/17)
+        running `cargo check --no-default-features --features a,b,default` on real (13/17)
+        running `cargo check --no-default-features --features c,default` on real (14/17)
+        running `cargo check --no-default-features --features a,c,default` on real (15/17)
+        running `cargo check --no-default-features --features b,c,default` on real (16/17)
+        running `cargo check --no-default-features --features a,b,c,default` on real (17/17)
         ",
     );
 
@@ -536,17 +537,18 @@ fn feature_powerset() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features --features a` on real (1/8)
-            running `cargo check --no-default-features --features a,b` on real (2/8)
-            running `cargo check --no-default-features --features a,c` on real (3/8)
-            running `cargo check --no-default-features --features a,b,c` on real (4/8)
-            running `cargo check --no-default-features --features a,default` on real (5/8)
-            running `cargo check --no-default-features --features a,b,default` on real (6/8)
-            running `cargo check --no-default-features --features a,c,default` on real (7/8)
-            running `cargo check --no-default-features --features a,b,c,default` on real (8/8)
+            running `cargo check --all-features --features a` on real (1/9)
+            running `cargo check --no-default-features --features a` on real (2/9)
+            running `cargo check --no-default-features --features a,b` on real (3/9)
+            running `cargo check --no-default-features --features a,c` on real (4/9)
+            running `cargo check --no-default-features --features a,b,c` on real (5/9)
+            running `cargo check --no-default-features --features a,default` on real (6/9)
+            running `cargo check --no-default-features --features a,b,default` on real (7/9)
+            running `cargo check --no-default-features --features a,c,default` on real (8/9)
+            running `cargo check --no-default-features --features a,b,c,default` on real (9/9)
             ",
         )
-        .stderr_not_contains("--features a,a");
+        .stderr_not_contains("a,a");
 }
 
 #[test]
@@ -574,16 +576,17 @@ fn powerset_deduplication() {
         .assert_success2("powerset_deduplication", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on deduplication (1/10)
-            running `cargo check --no-default-features --features a` on deduplication (2/10)
-            running `cargo check --no-default-features --features b` on deduplication (3/10)
-            running `cargo check --no-default-features --features c` on deduplication (4/10)
-            running `cargo check --no-default-features --features d` on deduplication (5/10)
-            running `cargo check --no-default-features --features a,d` on deduplication (6/10)
-            running `cargo check --no-default-features --features b,d` on deduplication (7/10)
-            running `cargo check --no-default-features --features c,d` on deduplication (8/10)
-            running `cargo check --no-default-features --features e` on deduplication (9/10)
-            running `cargo check --no-default-features --features c,e` on deduplication (10/10)
+            running `cargo check --all-features` on deduplication (1/11)
+            running `cargo check --no-default-features` on deduplication (2/11)
+            running `cargo check --no-default-features --features a` on deduplication (3/11)
+            running `cargo check --no-default-features --features b` on deduplication (4/11)
+            running `cargo check --no-default-features --features c` on deduplication (5/11)
+            running `cargo check --no-default-features --features d` on deduplication (6/11)
+            running `cargo check --no-default-features --features a,d` on deduplication (7/11)
+            running `cargo check --no-default-features --features b,d` on deduplication (8/11)
+            running `cargo check --no-default-features --features c,d` on deduplication (9/11)
+            running `cargo check --no-default-features --features e` on deduplication (10/11)
+            running `cargo check --no-default-features --features c,e` on deduplication (11/11)
             ",
         )
         .stderr_not_contains(
@@ -634,13 +637,14 @@ fn powerset_deduplication() {
         .assert_success2("powerset_deduplication", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on deduplication (1/7)
-            running `cargo check --no-default-features --features a` on deduplication (2/7)
-            running `cargo check --no-default-features --features c` on deduplication (3/7)
-            running `cargo check --no-default-features --features e` on deduplication (4/7)
-            running `cargo check --no-default-features --features c,e` on deduplication (5/7)
-            running `cargo check --no-default-features --features b,d` on deduplication (6/7)
-            running `cargo check --no-default-features --features c,b,d` on deduplication (7/7)
+            running `cargo check --all-features` on deduplication (1/8)
+            running `cargo check --no-default-features` on deduplication (2/8)
+            running `cargo check --no-default-features --features a` on deduplication (3/8)
+            running `cargo check --no-default-features --features c` on deduplication (4/8)
+            running `cargo check --no-default-features --features e` on deduplication (5/8)
+            running `cargo check --no-default-features --features c,e` on deduplication (6/8)
+            running `cargo check --no-default-features --features b,d` on deduplication (7/8)
+            running `cargo check --no-default-features --features c,b,d` on deduplication (8/8)
             ",
         )
         .stderr_not_contains(
@@ -662,11 +666,12 @@ fn powerset_deduplication() {
     .stderr_contains(
         "
         info: skipped applying group `b,d,not_found` to deduplication
-        info: running `cargo check --no-default-features` on deduplication (1/5)
-        info: running `cargo check --no-default-features --features a` on deduplication (2/5)
-        info: running `cargo check --no-default-features --features c` on deduplication (3/5)
-        info: running `cargo check --no-default-features --features e` on deduplication (4/5)
-        info: running `cargo check --no-default-features --features c,e` on deduplication (5/5)
+        info: running `cargo check --all-features` on deduplication (1/6)
+        info: running `cargo check --no-default-features` on deduplication (2/6)
+        info: running `cargo check --no-default-features --features a` on deduplication (3/6)
+        info: running `cargo check --no-default-features --features c` on deduplication (4/6)
+        info: running `cargo check --no-default-features --features e` on deduplication (5/6)
+        info: running `cargo check --no-default-features --features c,e` on deduplication (6/6)
         ",
     )
     .stderr_not_contains(
@@ -714,46 +719,47 @@ fn powerset_deduplication_include_deps_features() {
         .assert_success2("powerset_deduplication",  Some(if has_stable_toolchain() { 34 } else { 41 }))
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on deduplication (1/40)
-            running `cargo check --no-default-features --features a` on deduplication (2/40)
-            running `cargo check --no-default-features --features b` on deduplication (3/40)
-            running `cargo check --no-default-features --features c` on deduplication (4/40)
-            running `cargo check --no-default-features --features d` on deduplication (5/40)
-            running `cargo check --no-default-features --features a,d` on deduplication (6/40)
-            running `cargo check --no-default-features --features b,d` on deduplication (7/40)
-            running `cargo check --no-default-features --features c,d` on deduplication (8/40)
-            running `cargo check --no-default-features --features e` on deduplication (9/40)
-            running `cargo check --no-default-features --features c,e` on deduplication (10/40)
-            running `cargo check --no-default-features --features easytime/default` on deduplication (11/40)
-            running `cargo check --no-default-features --features a,easytime/default` on deduplication (12/40)
-            running `cargo check --no-default-features --features b,easytime/default` on deduplication (13/40)
-            running `cargo check --no-default-features --features c,easytime/default` on deduplication (14/40)
-            running `cargo check --no-default-features --features d,easytime/default` on deduplication (15/40)
-            running `cargo check --no-default-features --features a,d,easytime/default` on deduplication (16/40)
-            running `cargo check --no-default-features --features b,d,easytime/default` on deduplication (17/40)
-            running `cargo check --no-default-features --features c,d,easytime/default` on deduplication (18/40)
-            running `cargo check --no-default-features --features e,easytime/default` on deduplication (19/40)
-            running `cargo check --no-default-features --features c,e,easytime/default` on deduplication (20/40)
-            running `cargo check --no-default-features --features easytime/std` on deduplication (21/40)
-            running `cargo check --no-default-features --features a,easytime/std` on deduplication (22/40)
-            running `cargo check --no-default-features --features b,easytime/std` on deduplication (23/40)
-            running `cargo check --no-default-features --features c,easytime/std` on deduplication (24/40)
-            running `cargo check --no-default-features --features d,easytime/std` on deduplication (25/40)
-            running `cargo check --no-default-features --features a,d,easytime/std` on deduplication (26/40)
-            running `cargo check --no-default-features --features b,d,easytime/std` on deduplication (27/40)
-            running `cargo check --no-default-features --features c,d,easytime/std` on deduplication (28/40)
-            running `cargo check --no-default-features --features e,easytime/std` on deduplication (29/40)
-            running `cargo check --no-default-features --features c,e,easytime/std` on deduplication (30/40)
-            running `cargo check --no-default-features --features easytime/default,easytime/std` on deduplication (31/40)
-            running `cargo check --no-default-features --features a,easytime/default,easytime/std` on deduplication (32/40)
-            running `cargo check --no-default-features --features b,easytime/default,easytime/std` on deduplication (33/40)
-            running `cargo check --no-default-features --features c,easytime/default,easytime/std` on deduplication (34/40)
-            running `cargo check --no-default-features --features d,easytime/default,easytime/std` on deduplication (35/40)
-            running `cargo check --no-default-features --features a,d,easytime/default,easytime/std` on deduplication (36/40)
-            running `cargo check --no-default-features --features b,d,easytime/default,easytime/std` on deduplication (37/40)
-            running `cargo check --no-default-features --features c,d,easytime/default,easytime/std` on deduplication (38/40)
-            running `cargo check --no-default-features --features e,easytime/default,easytime/std` on deduplication (39/40)
-            running `cargo check --no-default-features --features c,e,easytime/default,easytime/std` on deduplication (40/40)
+            running `cargo check --all-features` on deduplication (1/41)
+            running `cargo check --no-default-features` on deduplication (2/41)
+            running `cargo check --no-default-features --features a` on deduplication (3/41)
+            running `cargo check --no-default-features --features b` on deduplication (4/41)
+            running `cargo check --no-default-features --features c` on deduplication (5/41)
+            running `cargo check --no-default-features --features d` on deduplication (6/41)
+            running `cargo check --no-default-features --features a,d` on deduplication (7/41)
+            running `cargo check --no-default-features --features b,d` on deduplication (8/41)
+            running `cargo check --no-default-features --features c,d` on deduplication (9/41)
+            running `cargo check --no-default-features --features e` on deduplication (10/41)
+            running `cargo check --no-default-features --features c,e` on deduplication (11/41)
+            running `cargo check --no-default-features --features easytime/default` on deduplication (12/41)
+            running `cargo check --no-default-features --features a,easytime/default` on deduplication (13/41)
+            running `cargo check --no-default-features --features b,easytime/default` on deduplication (14/41)
+            running `cargo check --no-default-features --features c,easytime/default` on deduplication (15/41)
+            running `cargo check --no-default-features --features d,easytime/default` on deduplication (16/41)
+            running `cargo check --no-default-features --features a,d,easytime/default` on deduplication (17/41)
+            running `cargo check --no-default-features --features b,d,easytime/default` on deduplication (18/41)
+            running `cargo check --no-default-features --features c,d,easytime/default` on deduplication (19/41)
+            running `cargo check --no-default-features --features e,easytime/default` on deduplication (20/41)
+            running `cargo check --no-default-features --features c,e,easytime/default` on deduplication (21/41)
+            running `cargo check --no-default-features --features easytime/std` on deduplication (22/41)
+            running `cargo check --no-default-features --features a,easytime/std` on deduplication (23/41)
+            running `cargo check --no-default-features --features b,easytime/std` on deduplication (24/41)
+            running `cargo check --no-default-features --features c,easytime/std` on deduplication (25/41)
+            running `cargo check --no-default-features --features d,easytime/std` on deduplication (26/41)
+            running `cargo check --no-default-features --features a,d,easytime/std` on deduplication (27/41)
+            running `cargo check --no-default-features --features b,d,easytime/std` on deduplication (28/41)
+            running `cargo check --no-default-features --features c,d,easytime/std` on deduplication (29/41)
+            running `cargo check --no-default-features --features e,easytime/std` on deduplication (30/41)
+            running `cargo check --no-default-features --features c,e,easytime/std` on deduplication (31/41)
+            running `cargo check --no-default-features --features easytime/default,easytime/std` on deduplication (32/41)
+            running `cargo check --no-default-features --features a,easytime/default,easytime/std` on deduplication (33/41)
+            running `cargo check --no-default-features --features b,easytime/default,easytime/std` on deduplication (34/41)
+            running `cargo check --no-default-features --features c,easytime/default,easytime/std` on deduplication (35/41)
+            running `cargo check --no-default-features --features d,easytime/default,easytime/std` on deduplication (36/41)
+            running `cargo check --no-default-features --features a,d,easytime/default,easytime/std` on deduplication (37/41)
+            running `cargo check --no-default-features --features b,d,easytime/default,easytime/std` on deduplication (38/41)
+            running `cargo check --no-default-features --features c,d,easytime/default,easytime/std` on deduplication (39/41)
+            running `cargo check --no-default-features --features e,easytime/default,easytime/std` on deduplication (40/41)
+            running `cargo check --no-default-features --features c,e,easytime/default,easytime/std` on deduplication (41/41)
             ",
         );
 }
@@ -778,7 +784,7 @@ fn feature_powerset_depth() {
             running `cargo check --no-default-features --features c,default` on real (12/12)
             ",
         )
-        .stderr_not_contains("--features a,b,c");
+        .stderr_not_contains("a,b,c");
 }
 
 #[test]
@@ -794,14 +800,15 @@ fn powerset_group_features() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on real (1/8)
-            running `cargo check --no-default-features --features c` on real (2/8)
-            running `cargo check --no-default-features --features default` on real (3/8)
-            running `cargo check --no-default-features --features c,default` on real (4/8)
-            running `cargo check --no-default-features --features a,b` on real (5/8)
-            running `cargo check --no-default-features --features c,a,b` on real (6/8)
-            running `cargo check --no-default-features --features default,a,b` on real (7/8)
-            running `cargo check --no-default-features --features c,default,a,b` on real (8/8)
+            running `cargo check --all-features` on real (1/9)
+            running `cargo check --no-default-features` on real (2/9)
+            running `cargo check --no-default-features --features c` on real (3/9)
+            running `cargo check --no-default-features --features default` on real (4/9)
+            running `cargo check --no-default-features --features c,default` on real (5/9)
+            running `cargo check --no-default-features --features a,b` on real (6/9)
+            running `cargo check --no-default-features --features c,a,b` on real (7/9)
+            running `cargo check --no-default-features --features default,a,b` on real (8/9)
+            running `cargo check --no-default-features --features c,default,a,b` on real (9/9)
             ",
         )
         .stderr_not_contains(
@@ -815,10 +822,11 @@ fn powerset_group_features() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on real (1/4)
-            running `cargo check --no-default-features --features default` on real (2/4)
-            running `cargo check --no-default-features --features a,b,c` on real (3/4)
-            running `cargo check --no-default-features --features default,a,b,c` on real (4/4)
+            running `cargo check --all-features` on real (1/5)
+            running `cargo check --no-default-features` on real (2/5)
+            running `cargo check --no-default-features --features default` on real (3/5)
+            running `cargo check --no-default-features --features a,b,c` on real (4/5)
+            running `cargo check --no-default-features --features default,a,b,c` on real (5/5)
             ",
         )
         .stderr_not_contains(
@@ -842,14 +850,15 @@ fn powerset_group_features() {
     .assert_success("real")
     .stderr_contains(
         "
-        running `cargo check --no-default-features` on real (1/8)
-        running `cargo check --no-default-features --features default` on real (2/8)
-        running `cargo check --no-default-features --features a,b` on real (3/8)
-        running `cargo check --no-default-features --features default,a,b` on real (4/8)
-        running `cargo check --no-default-features --features a,c` on real (5/8)
-        running `cargo check --no-default-features --features default,a,c` on real (6/8)
-        running `cargo check --no-default-features --features a,b,a,c` on real (7/8)
-        running `cargo check --no-default-features --features default,a,b,a,c` on real (8/8)
+        running `cargo check --all-features` on real (1/9)
+        running `cargo check --no-default-features` on real (2/9)
+        running `cargo check --no-default-features --features default` on real (3/9)
+        running `cargo check --no-default-features --features a,b` on real (4/9)
+        running `cargo check --no-default-features --features default,a,b` on real (5/9)
+        running `cargo check --no-default-features --features a,c` on real (6/9)
+        running `cargo check --no-default-features --features default,a,c` on real (7/9)
+        running `cargo check --no-default-features --features a,b,a,c` on real (8/9)
+        running `cargo check --no-default-features --features default,a,b,a,c` on real (9/9)
         ",
     )
     .stderr_not_contains(
@@ -1786,10 +1795,11 @@ fn namespaced_features() {
         .assert_success2("namespaced_features", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on namespaced_features (1/4)
-            running `cargo check --no-default-features --features combo` on namespaced_features (2/4)
-            running `cargo check --no-default-features --features explicit` on namespaced_features (3/4)
-            running `cargo check --no-default-features --features combo,explicit` on namespaced_features (4/4)
+            running `cargo check --all-features` on namespaced_features (1/5)
+            running `cargo check --no-default-features` on namespaced_features (2/5)
+            running `cargo check --no-default-features --features combo` on namespaced_features (3/5)
+            running `cargo check --no-default-features --features explicit` on namespaced_features (4/5)
+            running `cargo check --no-default-features --features combo,explicit` on namespaced_features (5/5)
             ",
         );
 }
@@ -1845,8 +1855,9 @@ fn weak_dep_features() {
         .assert_success2("weak_dep_features_implicit", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on weak_dep_features_implicit (1/2)
-            running `cargo check --no-default-features --features default` on weak_dep_features_implicit (2/2)
+            running `cargo check --all-features` on weak_dep_features_implicit (1/3)
+            running `cargo check --no-default-features` on weak_dep_features_implicit (2/3)
+            running `cargo check --no-default-features --features default` on weak_dep_features_implicit (3/3)
             ",
         );
     cargo_hack(["check", "--feature-powerset", "--optional-deps"])

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -603,22 +603,23 @@ fn powerset_deduplication() {
     // with --optional-deps
     cargo_hack(["check", "--feature-powerset", "--optional-deps"])
         .assert_success2("powerset_deduplication", require)
+        // TODO: c,e is actual biggest feature combination here
         .stderr_contains(
             "
             running `cargo check --no-default-features` on deduplication (1/14)
-            running `cargo check --no-default-features --features a` on deduplication (2/14)
-            running `cargo check --no-default-features --features b` on deduplication (3/14)
-            running `cargo check --no-default-features --features c` on deduplication (4/14)
-            running `cargo check --no-default-features --features d` on deduplication (5/14)
-            running `cargo check --no-default-features --features a,d` on deduplication (6/14)
-            running `cargo check --no-default-features --features b,d` on deduplication (7/14)
-            running `cargo check --no-default-features --features c,d` on deduplication (8/14)
-            running `cargo check --no-default-features --features e` on deduplication (9/14)
-            running `cargo check --no-default-features --features c,e` on deduplication (10/14)
-            running `cargo check --no-default-features --features member1` on deduplication (11/14)
-            running `cargo check --no-default-features --features a,member1` on deduplication (12/14)
-            running `cargo check --no-default-features --features b,member1` on deduplication (13/14)
-            running `cargo check --no-default-features --features c,member1` on deduplication (14/14)
+            running `cargo check --no-default-features --features c,member1` on deduplication (2/14)
+            running `cargo check --no-default-features --features a` on deduplication (3/14)
+            running `cargo check --no-default-features --features b` on deduplication (4/14)
+            running `cargo check --no-default-features --features c` on deduplication (5/14)
+            running `cargo check --no-default-features --features d` on deduplication (6/14)
+            running `cargo check --no-default-features --features a,d` on deduplication (7/14)
+            running `cargo check --no-default-features --features b,d` on deduplication (8/14)
+            running `cargo check --no-default-features --features c,d` on deduplication (9/14)
+            running `cargo check --no-default-features --features e` on deduplication (10/14)
+            running `cargo check --no-default-features --features c,e` on deduplication (11/14)
+            running `cargo check --no-default-features --features member1` on deduplication (12/14)
+            running `cargo check --no-default-features --features a,member1` on deduplication (13/14)
+            running `cargo check --no-default-features --features b,member1` on deduplication (14/14)
             ",
         )
         .stderr_not_contains(
@@ -688,15 +689,15 @@ fn powerset_deduplication() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on deduplication (1/10)
-            running `cargo check --no-default-features --features a` on deduplication (2/10)
-            running `cargo check --no-default-features --features c` on deduplication (3/10)
-            running `cargo check --no-default-features --features e` on deduplication (4/10)
-            running `cargo check --no-default-features --features c,e` on deduplication (5/10)
-            running `cargo check --no-default-features --features member1` on deduplication (6/10)
-            running `cargo check --no-default-features --features a,member1` on deduplication (7/10)
-            running `cargo check --no-default-features --features c,member1` on deduplication (8/10)
-            running `cargo check --no-default-features --features b,d` on deduplication (9/10)
-            running `cargo check --no-default-features --features c,b,d` on deduplication (10/10)
+            running `cargo check --no-default-features --features c,b,d` on deduplication (2/10)
+            running `cargo check --no-default-features --features a` on deduplication (3/10)
+            running `cargo check --no-default-features --features c` on deduplication (4/10)
+            running `cargo check --no-default-features --features e` on deduplication (5/10)
+            running `cargo check --no-default-features --features c,e` on deduplication (6/10)
+            running `cargo check --no-default-features --features member1` on deduplication (7/10)
+            running `cargo check --no-default-features --features a,member1` on deduplication (8/10)
+            running `cargo check --no-default-features --features c,member1` on deduplication (9/10)
+            running `cargo check --no-default-features --features b,d` on deduplication (10/10)
             ",
         )
         .stderr_not_contains(
@@ -899,9 +900,9 @@ fn include_features() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features --features a` on real (1/3)
-            running `cargo check --no-default-features --features b` on real (2/3)
-            running `cargo check --no-default-features --features a,b` on real (3/3)
+            running `cargo check --no-default-features --features a,b` on real (1/3)
+            running `cargo check --no-default-features --features a` on real (2/3)
+            running `cargo check --no-default-features --features b` on real (3/3)
             ",
         );
 }
@@ -1001,13 +1002,13 @@ fn powerset_skip_success() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on real (1/8)
-            running `cargo check --no-default-features --features b` on real (2/8)
-            running `cargo check --no-default-features --features c` on real (3/8)
-            running `cargo check --no-default-features --features b,c` on real (4/8)
-            running `cargo check --no-default-features --features default` on real (5/8)
-            running `cargo check --no-default-features --features b,default` on real (6/8)
-            running `cargo check --no-default-features --features c,default` on real (7/8)
-            running `cargo check --no-default-features --features b,c,default` on real (8/8)
+            running `cargo check --no-default-features --features b,c,default` on real (2/8)
+            running `cargo check --no-default-features --features b` on real (3/8)
+            running `cargo check --no-default-features --features c` on real (4/8)
+            running `cargo check --no-default-features --features b,c` on real (5/8)
+            running `cargo check --no-default-features --features default` on real (6/8)
+            running `cargo check --no-default-features --features b,default` on real (7/8)
+            running `cargo check --no-default-features --features c,default` on real (8/8)
             ",
         )
         .stderr_not_contains(
@@ -1814,9 +1815,9 @@ fn weak_dep_features() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on weak_dep_features (1/4)
-            running `cargo check --no-default-features --features default` on weak_dep_features (2/4)
-            running `cargo check --no-default-features --features easytime` on weak_dep_features (3/4)
-            running `cargo check --no-default-features --features default,easytime` on weak_dep_features (4/4)
+            running `cargo check --no-default-features --features default,easytime` on weak_dep_features (2/4)
+            running `cargo check --no-default-features --features default` on weak_dep_features (3/4)
+            running `cargo check --no-default-features --features easytime` on weak_dep_features (4/4)
             ",
         );
     cargo_hack(["check", "--feature-powerset", "--optional-deps"])
@@ -1824,9 +1825,9 @@ fn weak_dep_features() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on weak_dep_features (1/4)
-            running `cargo check --no-default-features --features default` on weak_dep_features (2/4)
-            running `cargo check --no-default-features --features easytime` on weak_dep_features (3/4)
-            running `cargo check --no-default-features --features default,easytime` on weak_dep_features (4/4)
+            running `cargo check --no-default-features --features default,easytime` on weak_dep_features (2/4)
+            running `cargo check --no-default-features --features default` on weak_dep_features (3/4)
+            running `cargo check --no-default-features --features easytime` on weak_dep_features (4/4)
             ",
         );
 
@@ -1835,9 +1836,9 @@ fn weak_dep_features() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on weak_dep_features_namespaced (1/4)
-            running `cargo check --no-default-features --features default` on weak_dep_features_namespaced (2/4)
-            running `cargo check --no-default-features --features easytime` on weak_dep_features_namespaced (3/4)
-            running `cargo check --no-default-features --features default,easytime` on weak_dep_features_namespaced (4/4)
+            running `cargo check --no-default-features --features default,easytime` on weak_dep_features_namespaced (2/4)
+            running `cargo check --no-default-features --features default` on weak_dep_features_namespaced (3/4)
+            running `cargo check --no-default-features --features easytime` on weak_dep_features_namespaced (4/4)
             ",
         );
     cargo_hack(["check", "--feature-powerset", "--optional-deps"])
@@ -1845,9 +1846,9 @@ fn weak_dep_features() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on weak_dep_features_namespaced (1/4)
-            running `cargo check --no-default-features --features default` on weak_dep_features_namespaced (2/4)
-            running `cargo check --no-default-features --features easytime` on weak_dep_features_namespaced (3/4)
-            running `cargo check --no-default-features --features default,easytime` on weak_dep_features_namespaced (4/4)
+            running `cargo check --no-default-features --features default,easytime` on weak_dep_features_namespaced (2/4)
+            running `cargo check --no-default-features --features default` on weak_dep_features_namespaced (3/4)
+            running `cargo check --no-default-features --features easytime` on weak_dep_features_namespaced (4/4)
             ",
         );
 
@@ -1865,9 +1866,9 @@ fn weak_dep_features() {
         .stderr_contains(
             "
             running `cargo check --no-default-features` on weak_dep_features_implicit (1/4)
-            running `cargo check --no-default-features --features default` on weak_dep_features_implicit (2/4)
-            running `cargo check --no-default-features --features easytime` on weak_dep_features_implicit (3/4)
-            running `cargo check --no-default-features --features default,easytime` on weak_dep_features_implicit (4/4)
+            running `cargo check --no-default-features --features default,easytime` on weak_dep_features_implicit (2/4)
+            running `cargo check --no-default-features --features default` on weak_dep_features_implicit (3/4)
+            running `cargo check --no-default-features --features easytime` on weak_dep_features_implicit (4/4)
             ",
         );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -469,12 +469,12 @@ fn ignore_unknown_features_failure() {
 fn each_feature() {
     cargo_hack(["check", "--each-feature"]).assert_success("real").stderr_contains(
         "
-        running `cargo check --no-default-features` on real (1/6)
-        running `cargo check --no-default-features --features a` on real (2/6)
-        running `cargo check --no-default-features --features b` on real (3/6)
-        running `cargo check --no-default-features --features c` on real (4/6)
-        running `cargo check --no-default-features --features default` on real (5/6)
-        running `cargo check --no-default-features --all-features` on real (6/6)
+        running `cargo check --all-features` on real (1/6)
+        running `cargo check --no-default-features` on real (2/6)
+        running `cargo check --no-default-features --features a` on real (3/6)
+        running `cargo check --no-default-features --features b` on real (4/6)
+        running `cargo check --no-default-features --features c` on real (5/6)
+        running `cargo check --no-default-features --features default` on real (6/6)
         ",
     );
 
@@ -483,11 +483,11 @@ fn each_feature() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features --features a` on real (1/5)
-            running `cargo check --no-default-features --features a,b` on real (2/5)
-            running `cargo check --no-default-features --features a,c` on real (3/5)
-            running `cargo check --no-default-features --features a,default` on real (4/5)
-            running `cargo check --no-default-features --all-features --features a` on real (5/5)
+            running `cargo check --all-features --features a` on real (1/5)
+            running `cargo check --no-default-features --features a` on real (2/5)
+            running `cargo check --no-default-features --features a,b` on real (3/5)
+            running `cargo check --no-default-features --features a,c` on real (4/5)
+            running `cargo check --no-default-features --features a,default` on real (5/5)
             ",
         )
         .stderr_not_contains("--features a,a");
@@ -764,18 +764,18 @@ fn feature_powerset_depth() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on real (1/12)
-            running `cargo check --no-default-features --features a` on real (2/12)
-            running `cargo check --no-default-features --features b` on real (3/12)
-            running `cargo check --no-default-features --features a,b` on real (4/12)
-            running `cargo check --no-default-features --features c` on real (5/12)
-            running `cargo check --no-default-features --features a,c` on real (6/12)
-            running `cargo check --no-default-features --features b,c` on real (7/12)
-            running `cargo check --no-default-features --features default` on real (8/12)
-            running `cargo check --no-default-features --features a,default` on real (9/12)
-            running `cargo check --no-default-features --features b,default` on real (10/12)
-            running `cargo check --no-default-features --features c,default` on real (11/12)
-            running `cargo check --no-default-features --all-features` on real (12/12)
+            running `cargo check --all-features` on real (1/12)
+            running `cargo check --no-default-features` on real (2/12)
+            running `cargo check --no-default-features --features a` on real (3/12)
+            running `cargo check --no-default-features --features b` on real (4/12)
+            running `cargo check --no-default-features --features a,b` on real (5/12)
+            running `cargo check --no-default-features --features c` on real (6/12)
+            running `cargo check --no-default-features --features a,c` on real (7/12)
+            running `cargo check --no-default-features --features b,c` on real (8/12)
+            running `cargo check --no-default-features --features default` on real (9/12)
+            running `cargo check --no-default-features --features a,default` on real (10/12)
+            running `cargo check --no-default-features --features b,default` on real (11/12)
+            running `cargo check --no-default-features --features c,default` on real (12/12)
             ",
         )
         .stderr_not_contains("--features a,b,c");
@@ -1032,11 +1032,11 @@ fn exclude_no_default_features() {
         .assert_success("real")
         .stderr_contains(
             "
-            running `cargo check --no-default-features --features a` on real (1/5)
-            running `cargo check --no-default-features --features b` on real (2/5)
-            running `cargo check --no-default-features --features c` on real (3/5)
-            running `cargo check --no-default-features --features default` on real (4/5)
-            running `cargo check --no-default-features --all-features` on real (5/5)
+            running `cargo check --all-features` on real (1/5)
+            running `cargo check --no-default-features --features a` on real (2/5)
+            running `cargo check --no-default-features --features b` on real (3/5)
+            running `cargo check --no-default-features --features c` on real (4/5)
+            running `cargo check --no-default-features --features default` on real (5/5)
             ",
         )
         .stderr_not_contains("running `cargo check --no-default-features` on real");
@@ -1064,7 +1064,7 @@ fn exclude_all_features() {
             running `cargo check --no-default-features --features default` on real (5/5)
             ",
         )
-        .stderr_not_contains("running `cargo check --no-default-features --all-features` on real");
+        .stderr_not_contains("--all-features");
 }
 
 #[test]
@@ -1080,30 +1080,30 @@ fn exclude_all_features_failure() {
 fn each_feature_all() {
     cargo_hack(["check", "--each-feature", "--workspace"]).assert_success("real").stderr_contains(
         "
-        running `cargo check --no-default-features` on member1 (1/24)
-        running `cargo check --no-default-features --features a` on member1 (2/24)
-        running `cargo check --no-default-features --features b` on member1 (3/24)
-        running `cargo check --no-default-features --features c` on member1 (4/24)
-        running `cargo check --no-default-features --features default` on member1 (5/24)
-        running `cargo check --no-default-features --all-features` on member1 (6/24)
-        running `cargo check --no-default-features` on member2 (7/24)
-        running `cargo check --no-default-features --features a` on member2 (8/24)
-        running `cargo check --no-default-features --features b` on member2 (9/24)
-        running `cargo check --no-default-features --features c` on member2 (10/24)
-        running `cargo check --no-default-features --features default` on member2 (11/24)
-        running `cargo check --no-default-features --all-features` on member2 (12/24)
-        running `cargo check --no-default-features` on member3 (13/24)
-        running `cargo check --no-default-features --features a` on member3 (14/24)
-        running `cargo check --no-default-features --features b` on member3 (15/24)
-        running `cargo check --no-default-features --features c` on member3 (16/24)
-        running `cargo check --no-default-features --features default` on member3 (17/24)
-        running `cargo check --no-default-features --all-features` on member3 (18/24)
-        running `cargo check --no-default-features` on real (19/24)
-        running `cargo check --no-default-features --features a` on real (20/24)
-        running `cargo check --no-default-features --features b` on real (21/24)
-        running `cargo check --no-default-features --features c` on real (22/24)
-        running `cargo check --no-default-features --features default` on real (23/24)
-        running `cargo check --no-default-features --all-features` on real (24/24)
+        running `cargo check --all-features` on member1 (1/24)
+        running `cargo check --no-default-features` on member1 (2/24)
+        running `cargo check --no-default-features --features a` on member1 (3/24)
+        running `cargo check --no-default-features --features b` on member1 (4/24)
+        running `cargo check --no-default-features --features c` on member1 (5/24)
+        running `cargo check --no-default-features --features default` on member1 (6/24)
+        running `cargo check --all-features` on member2 (7/24)
+        running `cargo check --no-default-features` on member2 (8/24)
+        running `cargo check --no-default-features --features a` on member2 (9/24)
+        running `cargo check --no-default-features --features b` on member2 (10/24)
+        running `cargo check --no-default-features --features c` on member2 (11/24)
+        running `cargo check --no-default-features --features default` on member2 (12/24)
+        running `cargo check --all-features` on member3 (13/24)
+        running `cargo check --no-default-features` on member3 (14/24)
+        running `cargo check --no-default-features --features a` on member3 (15/24)
+        running `cargo check --no-default-features --features b` on member3 (16/24)
+        running `cargo check --no-default-features --features c` on member3 (17/24)
+        running `cargo check --no-default-features --features default` on member3 (18/24)
+        running `cargo check --all-features` on real (19/24)
+        running `cargo check --no-default-features` on real (20/24)
+        running `cargo check --no-default-features --features a` on real (21/24)
+        running `cargo check --no-default-features --features b` on real (22/24)
+        running `cargo check --no-default-features --features c` on real (23/24)
+        running `cargo check --no-default-features --features default` on real (24/24)
         ",
     );
 }
@@ -1114,15 +1114,15 @@ fn include_deps_features() {
         .assert_success2("powerset_deduplication",  Some(if has_stable_toolchain() { 34 } else { 41 }))
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on deduplication (1/9)
-            running `cargo check --no-default-features --features a` on deduplication (2/9)
-            running `cargo check --no-default-features --features b` on deduplication (3/9)
-            running `cargo check --no-default-features --features c` on deduplication (4/9)
-            running `cargo check --no-default-features --features d` on deduplication (5/9)
-            running `cargo check --no-default-features --features e` on deduplication (6/9)
-            running `cargo check --no-default-features --features easytime/default` on deduplication (7/9)
-            running `cargo check --no-default-features --features easytime/std` on deduplication (8/9)
-            running `cargo check --no-default-features --all-features` on deduplication (9/9)
+            running `cargo check --all-features` on deduplication (1/9)
+            running `cargo check --no-default-features` on deduplication (2/9)
+            running `cargo check --no-default-features --features a` on deduplication (3/9)
+            running `cargo check --no-default-features --features b` on deduplication (4/9)
+            running `cargo check --no-default-features --features c` on deduplication (5/9)
+            running `cargo check --no-default-features --features d` on deduplication (6/9)
+            running `cargo check --no-default-features --features e` on deduplication (7/9)
+            running `cargo check --no-default-features --features easytime/default` on deduplication (8/9)
+            running `cargo check --no-default-features --features easytime/std` on deduplication (9/9)
             ",
         );
 }
@@ -1221,8 +1221,8 @@ fn optional_deps() {
         .assert_success2("optional_deps", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on optional_deps (1/2)
-            running `cargo check --no-default-features --all-features` on optional_deps (2/2)
+            running `cargo check --all-features` on optional_deps (1/2)
+            running `cargo check --no-default-features` on optional_deps (2/2)
             ",
         )
         .stderr_not_contains(
@@ -1236,10 +1236,10 @@ fn optional_deps() {
         .assert_success2("optional_deps", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on optional_deps (1/4)
-            running `cargo check --no-default-features --features real` on optional_deps (2/4)
-            running `cargo check --no-default-features --features renamed` on optional_deps (3/4)
-            running `cargo check --no-default-features --all-features` on optional_deps (4/4)
+            running `cargo check --all-features` on optional_deps (1/4)
+            running `cargo check --no-default-features` on optional_deps (2/4)
+            running `cargo check --no-default-features --features real` on optional_deps (3/4)
+            running `cargo check --no-default-features --features renamed` on optional_deps (4/4)
             ",
         );
 
@@ -1247,9 +1247,9 @@ fn optional_deps() {
         .assert_success2("optional_deps", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on optional_deps (1/3)
-            running `cargo check --no-default-features --features real` on optional_deps (2/3)
-            running `cargo check --no-default-features --all-features` on optional_deps (3/3)
+            running `cargo check --all-features` on optional_deps (1/3)
+            running `cargo check --no-default-features` on optional_deps (2/3)
+            running `cargo check --no-default-features --features real` on optional_deps (3/3)
             ",
         )
         .stderr_not_contains("--features renamed");
@@ -1258,9 +1258,9 @@ fn optional_deps() {
         .assert_success2("optional_deps", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on optional_deps (1/3)
-            running `cargo check --no-default-features --features renamed` on optional_deps (2/3)
-            running `cargo check --no-default-features --all-features` on optional_deps (3/3)
+            running `cargo check --all-features` on optional_deps (1/3)
+            running `cargo check --no-default-features` on optional_deps (2/3)
+            running `cargo check --no-default-features --features renamed` on optional_deps (3/3)
             ",
         )
         .stderr_not_contains("--features real");
@@ -1269,8 +1269,8 @@ fn optional_deps() {
         .assert_success2("optional_deps", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on optional_deps (1/2)
-            running `cargo check --no-default-features --all-features` on optional_deps (2/2)
+            running `cargo check --all-features` on optional_deps (1/2)
+            running `cargo check --no-default-features` on optional_deps (2/2)
             ",
         );
 }
@@ -1719,10 +1719,10 @@ fn namespaced_features() {
         .assert_success2("namespaced_features", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on namespaced_features (1/4)
-            running `cargo check --no-default-features --features combo` on namespaced_features (2/4)
-            running `cargo check --no-default-features --features explicit` on namespaced_features (3/4)
-            running `cargo check --no-default-features --all-features` on namespaced_features (4/4)
+            running `cargo check --all-features` on namespaced_features (1/4)
+            running `cargo check --no-default-features` on namespaced_features (2/4)
+            running `cargo check --no-default-features --features combo` on namespaced_features (3/4)
+            running `cargo check --no-default-features --features explicit` on namespaced_features (4/4)
             ",
         )
         .stderr_not_contains(
@@ -1736,12 +1736,12 @@ fn namespaced_features() {
         .assert_success2("namespaced_features", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on namespaced_features (1/6)
-            running `cargo check --no-default-features --features combo` on namespaced_features (2/6)
-            running `cargo check --no-default-features --features explicit` on namespaced_features (3/6)
-            running `cargo check --no-default-features --features implicit` on namespaced_features (4/6)
-            running `cargo check --no-default-features --features renamed` on namespaced_features (5/6)
-            running `cargo check --no-default-features --all-features` on namespaced_features (6/6)
+            running `cargo check --all-features` on namespaced_features (1/6)
+            running `cargo check --no-default-features` on namespaced_features (2/6)
+            running `cargo check --no-default-features --features combo` on namespaced_features (3/6)
+            running `cargo check --no-default-features --features explicit` on namespaced_features (4/6)
+            running `cargo check --no-default-features --features implicit` on namespaced_features (5/6)
+            running `cargo check --no-default-features --features renamed` on namespaced_features (6/6)
             ",
         );
 
@@ -1749,11 +1749,11 @@ fn namespaced_features() {
         .assert_success2("namespaced_features", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on namespaced_features (1/5)
-            running `cargo check --no-default-features --features combo` on namespaced_features (2/5)
-            running `cargo check --no-default-features --features explicit` on namespaced_features (3/5)
-            running `cargo check --no-default-features --features implicit` on namespaced_features (4/5)
-            running `cargo check --no-default-features --all-features` on namespaced_features (5/5)
+            running `cargo check --all-features` on namespaced_features (1/5)
+            running `cargo check --no-default-features` on namespaced_features (2/5)
+            running `cargo check --no-default-features --features combo` on namespaced_features (3/5)
+            running `cargo check --no-default-features --features explicit` on namespaced_features (4/5)
+            running `cargo check --no-default-features --features implicit` on namespaced_features (5/5)
             ",
         )
         .stderr_not_contains("--features renamed");
@@ -1762,11 +1762,11 @@ fn namespaced_features() {
         .assert_success2("namespaced_features", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on namespaced_features (1/5)
-            running `cargo check --no-default-features --features combo` on namespaced_features (2/5)
-            running `cargo check --no-default-features --features explicit` on namespaced_features (3/5)
-            running `cargo check --no-default-features --features renamed` on namespaced_features (4/5)
-            running `cargo check --no-default-features --all-features` on namespaced_features (5/5)
+            running `cargo check --all-features` on namespaced_features (1/5)
+            running `cargo check --no-default-features` on namespaced_features (2/5)
+            running `cargo check --no-default-features --features combo` on namespaced_features (3/5)
+            running `cargo check --no-default-features --features explicit` on namespaced_features (4/5)
+            running `cargo check --no-default-features --features renamed` on namespaced_features (5/5)
             ",
         )
         .stderr_not_contains("--features implicit");
@@ -1775,10 +1775,10 @@ fn namespaced_features() {
         .assert_success2("namespaced_features", require)
         .stderr_contains(
             "
-            running `cargo check --no-default-features` on namespaced_features (1/4)
-            running `cargo check --no-default-features --features combo` on namespaced_features (2/4)
-            running `cargo check --no-default-features --features explicit` on namespaced_features (3/4)
-            running `cargo check --no-default-features --all-features` on namespaced_features (4/4)
+            running `cargo check --all-features` on namespaced_features (1/4)
+            running `cargo check --no-default-features` on namespaced_features (2/4)
+            running `cargo check --no-default-features --features combo` on namespaced_features (3/4)
+            running `cargo check --no-default-features --features explicit` on namespaced_features (4/4)
             ",
         );
 
@@ -1874,12 +1874,12 @@ fn print_command_list() {
         .assert_success("real")
         .stdout_contains(
             "
+            cargo check --manifest-path Cargo.toml --all-features
             cargo check --manifest-path Cargo.toml --no-default-features
             cargo check --manifest-path Cargo.toml --no-default-features --features a
             cargo check --manifest-path Cargo.toml --no-default-features --features b
             cargo check --manifest-path Cargo.toml --no-default-features --features c
             cargo check --manifest-path Cargo.toml --no-default-features --features default
-            cargo check --manifest-path Cargo.toml --no-default-features --all-features
             ",
         )
         .stdout_not_contains("`");


### PR DESCRIPTION
Closes #246

The first and third commits are directly related to this behavior; the second commit is a fix to the related behavior.

---

**--all-features case:** --all-features case moved from the last to the first

From:
```
info: running `cargo check --no-default-features` on optional_deps (1/4)
info: running `cargo check --no-default-features --features real` on optional_deps (2/4)
info: running `cargo check --no-default-features --features renamed` on optional_deps (3/4)
info: running `cargo check --no-default-features --all-features` on optional_deps (4/4)
```
To:
```
info: running `cargo check --all-features` on optional_deps (1/4)
info: running `cargo check --no-default-features` on optional_deps (2/4)
info: running `cargo check --no-default-features --features real` on optional_deps (3/4)
info: running `cargo check --no-default-features --features renamed` on optional_deps (4/4)
```

---

**non --all-features case:** the biggest feature combination case (in this case, default,easytime) moved from the last to the second (last -> first when --exclude-no-default-features passed)

From:
```
info: running `cargo check --no-default-features` on weak_dep_features (1/4)
info: running `cargo check --no-default-features --features default` on weak_dep_features (2/4)
info: running `cargo check --no-default-features --features easytime` on weak_dep_features (3/4)
info: running `cargo check --no-default-features --features default,easytime` on weak_dep_features (4/4)
```
To:
```
info: running `cargo check --no-default-features` on weak_dep_features (1/4)
info: running `cargo check --no-default-features --features default,easytime` on weak_dep_features (2/4)
info: running `cargo check --no-default-features --features default` on weak_dep_features (3/4)
info: running `cargo check --no-default-features --features easytime` on weak_dep_features (4/4)
```

The reason it is not always run first is that there is no good way to implement it other than duplicating the code in 3 places or moving the "--no-default-features without --features" case to the last (I don't want to move it to the last because that is another "case where it is likely to find a problem").