### PR TITLE
add illumos release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-2019
           - target: x86_64-unknown-freebsd
+          - target: x86_64-unknown-illumos
           - target: universal-apple-darwin
             os: macos-12
     runs-on: ${{ matrix.os || 'ubuntu-20.04' }}


### PR DESCRIPTION
Following up on https://github.com/taiki-e/setup-cross-toolchain-action/issues/2#issuecomment-2220940071 now that we have https://github.com/taiki-e/setup-cross-toolchain-action/pull/22 merged. 