### PR TITLE
Add --partition M/N to distribute builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ OPTIONS:
         --keep-going
             Keep going on failure.
 
+        --partition <M/N>
+            Partition runs and execute only its subset according to M/N.
+
         --log-group <KIND>
             Log grouping: none, github-actions.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ use lexopt::{
     ValueExt,
 };
 
-use crate::{term, version::VersionRange, Feature, LogGroup, Rustup};
+use crate::{term, version::VersionRange, Feature, LogGroup, Partition, Rustup};
 
 pub(crate) struct Args {
     pub(crate) leading_args: Vec<String>,
@@ -53,6 +53,8 @@ pub(crate) struct Args {
     pub(crate) clean_per_version: bool,
     /// --keep-going
     pub(crate) keep_going: bool,
+    /// --partition
+    pub(crate) partition: Option<Partition>,
     /// --print-command-list
     pub(crate) print_command_list: bool,
     /// --version-range/--rust-version
@@ -155,6 +157,7 @@ impl Args {
         let mut clean_per_run = false;
         let mut clean_per_version = false;
         let mut keep_going = false;
+        let mut partition = None;
         let mut print_command_list = false;
         let mut no_manifest_path = false;
         let mut locked = false;
@@ -308,6 +311,7 @@ impl Args {
                 Long("clean-per-run") => parse_flag!(clean_per_run),
                 Long("clean-per-version") => parse_flag!(clean_per_version),
                 Long("keep-going") => parse_flag!(keep_going),
+                Long("partition") => parse_opt!(partition, false),
                 Long("print-command-list") => parse_flag!(print_command_list),
                 Long("no-manifest-path") => parse_flag!(no_manifest_path),
                 Long("locked") => parse_flag!(locked),
@@ -571,6 +575,8 @@ impl Args {
             None => LogGroup::auto(),
         };
 
+        let partition = partition.as_deref().map(str::parse).transpose()?;
+
         if no_dev_deps || no_private {
             let flag = if no_dev_deps && no_private {
                 "--no-dev-deps and --no-private modify"
@@ -620,6 +626,7 @@ impl Args {
             clean_per_run,
             clean_per_version,
             keep_going,
+            partition,
             print_command_list,
             no_manifest_path,
             include_features: include_features.into_iter().map(Into::into).collect(),
@@ -813,6 +820,7 @@ const HELP: &[HelpText<'_>] = &[
         "This flag can only be used together with --version-range flag.",
     ]),
     ("", "--keep-going", "", "Keep going on failure", &[]),
+    ("", "--partition", "<M/N>", "Partition runs and execute only its subset according to M/N", &[]),
     ("", "--log-group", "<KIND>", "Log grouping: none, github-actions", &[
         "If this option is not used, the environment will be automatically detected."
     ]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,12 @@ struct Progress {
 
 impl Progress {
     fn in_partition(&self, partition: &Partition) -> bool {
-        let current_index = self.count / self.total.div_ceil(partition.count);
+        // div_ceil (stabilized at 1.73) can't be used due to MSRV = 1.70...
+        let mut chunk_count = self.total / partition.count;
+        if self.total % partition.count != 0 {
+            chunk_count += 1;
+        }
+        let current_index = self.count / chunk_count;
         current_index == partition.index
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,10 +701,9 @@ fn exec_cargo_inner(
         eprintln!();
     }
 
-    let new_count = progress.count + 1;
     if let Some(partition) = &cx.partition {
         if !progress.in_partition(partition) {
-            let _guard = log_and_update_progress(cx, id, line, progress, new_count, "skipping");
+            let _guard = log_and_update_progress(cx, id, line, progress, "skipping");
             return Ok(());
         }
     }
@@ -718,7 +717,7 @@ fn exec_cargo_inner(
         return Ok(());
     }
 
-    let _guard = log_and_update_progress(cx, id, line, progress, new_count, "running");
+    let _guard = log_and_update_progress(cx, id, line, progress, "running");
 
     line.run()
 }
@@ -759,7 +758,6 @@ fn log_and_update_progress(
     id: &PackageId,
     line: &ProcessBuilder<'_>,
     progress: &mut Progress,
-    new_count: usize,
     action: &str,
 ) -> Option<LogGroupGuard> {
     // running/skipping `<command>` (on <package>) (<count>/<total>)
@@ -769,7 +767,7 @@ fn log_and_update_progress(
     } else {
         write!(msg, "{action} {line} on {}", cx.packages(id).name).unwrap();
     }
-    write!(msg, " ({}/{})", new_count, progress.total).unwrap();
-    progress.count = new_count;
+    progress.count += 1;
+    write!(msg, " ({}/{})", progress.count, progress.total).unwrap();
     cx.log_group.print(&msg)
 }

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -186,6 +186,9 @@ OPTIONS:
         --keep-going
             Keep going on failure.
 
+        --partition <M/N>
+            Partition runs and execute only its subset according to M/N.
+
         --log-group <KIND>
             Log grouping: none, github-actions.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -46,6 +46,8 @@ OPTIONS:
                                          command
         --clean-per-version              Remove artifacts per Rust version
         --keep-going                     Keep going on failure
+        --partition <M/N>                Partition runs and execute only its subset according to
+                                         M/N
         --log-group <KIND>               Log grouping: none, github-actions
         --print-command-list             Print commands without run (Unstable)
         --no-manifest-path               Do not pass --manifest-path option to cargo (Unstable)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1980,6 +1980,10 @@ fn partition_bad() {
         .assert_failure("real")
         .stderr_contains("bad or out-of-range partition: foo/bar");
 
+    cargo_hack(["check", "--each-feature", "--partition", "2/0"])
+        .assert_failure("real")
+        .stderr_contains("bad or out-of-range partition: 2/0");
+
     cargo_hack(["check", "--each-feature", "--partition", "0/3"])
         .assert_failure("real")
         .stderr_contains("bad or out-of-range partition: 0/3");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1898,3 +1898,106 @@ fn print_command_list() {
         )
         .stdout_not_contains("`");
 }
+
+#[test]
+fn partition() {
+    cargo_hack(["check", "--feature-powerset", "--partition", "1/3"])
+        .assert_success("real")
+        .stderr_contains(
+            "
+            running `cargo check --all-features` on real (1/17)
+            running `cargo check --no-default-features` on real (2/17)
+            running `cargo check --no-default-features --features a` on real (3/17)
+            running `cargo check --no-default-features --features b` on real (4/17)
+            running `cargo check --no-default-features --features a,b` on real (5/17)
+            running `cargo check --no-default-features --features c` on real (6/17)
+            skipping `cargo check --no-default-features --features a,c` on real (7/17)
+            skipping `cargo check --no-default-features --features b,c` on real (8/17)
+            skipping `cargo check --no-default-features --features a,b,c` on real (9/17)
+            skipping `cargo check --no-default-features --features default` on real (10/17)
+            skipping `cargo check --no-default-features --features a,default` on real (11/17)
+            skipping `cargo check --no-default-features --features b,default` on real (12/17)
+            skipping `cargo check --no-default-features --features a,b,default` on real (13/17)
+            skipping `cargo check --no-default-features --features c,default` on real (14/17)
+            skipping `cargo check --no-default-features --features a,c,default` on real (15/17)
+            skipping `cargo check --no-default-features --features b,c,default` on real (16/17)
+            skipping `cargo check --no-default-features --features a,b,c,default` on real (17/17)
+            ",
+        );
+
+    cargo_hack(["check", "--feature-powerset", "--partition", "2/3"])
+        .assert_success("real")
+        .stderr_contains(
+            "
+            skipping `cargo check --all-features` on real (1/17)
+            skipping `cargo check --no-default-features` on real (2/17)
+            skipping `cargo check --no-default-features --features a` on real (3/17)
+            skipping `cargo check --no-default-features --features b` on real (4/17)
+            skipping `cargo check --no-default-features --features a,b` on real (5/17)
+            skipping `cargo check --no-default-features --features c` on real (6/17)
+            running `cargo check --no-default-features --features a,c` on real (7/17)
+            running `cargo check --no-default-features --features b,c` on real (8/17)
+            running `cargo check --no-default-features --features a,b,c` on real (9/17)
+            running `cargo check --no-default-features --features default` on real (10/17)
+            running `cargo check --no-default-features --features a,default` on real (11/17)
+            running `cargo check --no-default-features --features b,default` on real (12/17)
+            skipping `cargo check --no-default-features --features a,b,default` on real (13/17)
+            skipping `cargo check --no-default-features --features c,default` on real (14/17)
+            skipping `cargo check --no-default-features --features a,c,default` on real (15/17)
+            skipping `cargo check --no-default-features --features b,c,default` on real (16/17)
+            skipping `cargo check --no-default-features --features a,b,c,default` on real (17/17)
+            ",
+        );
+
+    cargo_hack(["check", "--feature-powerset", "--partition", "3/3"])
+        .assert_success("real")
+        .stderr_contains(
+            "
+            skipping `cargo check --all-features` on real (1/17)
+            skipping `cargo check --no-default-features` on real (2/17)
+            skipping `cargo check --no-default-features --features a` on real (3/17)
+            skipping `cargo check --no-default-features --features b` on real (4/17)
+            skipping `cargo check --no-default-features --features a,b` on real (5/17)
+            skipping `cargo check --no-default-features --features c` on real (6/17)
+            skipping `cargo check --no-default-features --features a,c` on real (7/17)
+            skipping `cargo check --no-default-features --features b,c` on real (8/17)
+            skipping `cargo check --no-default-features --features a,b,c` on real (9/17)
+            skipping `cargo check --no-default-features --features default` on real (10/17)
+            skipping `cargo check --no-default-features --features a,default` on real (11/17)
+            skipping `cargo check --no-default-features --features b,default` on real (12/17)
+            running `cargo check --no-default-features --features a,b,default` on real (13/17)
+            running `cargo check --no-default-features --features c,default` on real (14/17)
+            running `cargo check --no-default-features --features a,c,default` on real (15/17)
+            running `cargo check --no-default-features --features b,c,default` on real (16/17)
+            running `cargo check --no-default-features --features a,b,c,default` on real (17/17)
+            ",
+        );
+}
+
+#[test]
+fn partition_bad() {
+    cargo_hack(["check", "--each-feature", "--partition", "foo/bar"])
+        .assert_failure("real")
+        .stderr_contains("bad or out-of-range partition: foo/bar");
+
+    cargo_hack(["check", "--each-feature", "--partition", "0/3"])
+        .assert_failure("real")
+        .stderr_contains("bad or out-of-range partition: 0/3");
+
+    cargo_hack(["check", "--each-feature", "--partition", "4/3"])
+        .assert_failure("real")
+        .stderr_contains("bad or out-of-range partition: 4/3");
+
+    cargo_hack([
+        "check",
+        "--each-feature",
+        "--partition",
+        "1/3",
+        "--partition",
+        "2/3",
+    ])
+    .assert_failure("real")
+    .stderr_contains(
+        "The argument '--partition' was provided more than once, but cannot be used multiple times",
+    );
+}


### PR DESCRIPTION
if there are many workspace members, it takes very long to execute all runs. So, introduce `--partition M/N` to distribute runs across machines.

This pr is in draft still. If this addition of new flag sounds acceptable, I'll finish up it (maybe, writing tests and improve cli handling (edit: DONE), update docs?)

demo: https://buildkite.com/anza/agave/builds/7618#0190b45e-b9e3-4b64-a172-4d9fc6b52e0f

related: #180, #248 (... in the sense this is about accelerating the whole step of `cargo hack` in CIs)

the exact behavior is moderately mirrored from the counted partitioning of nextest: https://nexte.st/docs/ci-features/partitioning/#counted-partitioning

context: https://github.com/rust-lang/cargo/issues/10958#issuecomment-2214005359 and https://github.com/rust-lang/cargo/issues/8379#issuecomment-2201882061