### PR TITLE
Add --random option

### DIFF
--- a/.github/.cspell/rust-dependencies.txt
+++ b/.github/.cspell/rust-dependencies.txt
@@ -3,5 +3,6 @@
 
 argfile
 easytime
+fastrand
 lexopt
 termcolor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           cd tests/fixtures/real
           cargo hack check --feature-powerset --workspace
           cargo hack check --feature-powerset --workspace --message-format=json
+          # TODO: move to tests/test.rs
+          cargo hack check --feature-powerset --workspace --optional-deps --random 20
           cd ../rust-version
           rustup toolchain remove 1.63 1.64 1.65
           cargo hack check --rust-version --workspace --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ pkg-fmt = "tgz"
 anyhow = "1.0.47"
 cargo-config2 = "0.1.13"
 ctrlc = { version = "3.4.4", features = ["termination"] }
+fastrand = "2"
 lexopt = "0.3"
 same-file = "1.0.1"
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --random <NUM_SAMPLES>
+            Performs with random feature combinations up to the number specified per crate.
+
+            This flag can only be used together with --feature-powerset flag.
+
         --group-features <FEATURES>...
             Space or comma separated list of features to group.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,6 +278,7 @@ fn determine_kind<'a>(
         let features = features::feature_powerset(
             features,
             cx.depth,
+            cx.random,
             &cx.at_least_one_of,
             &cx.mutually_exclusive_features,
             &package.features,

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -92,6 +92,11 @@ OPTIONS:
 
             This flag can only be used together with --feature-powerset flag.
 
+        --random <NUM_SAMPLES>
+            Performs with random feature combinations up to the number specified per crate.
+
+            This flag can only be used together with --feature-powerset flag.
+
         --group-features <FEATURES>...
             Space or comma separated list of features to group.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -23,6 +23,8 @@ OPTIONS:
         --exclude-all-features           Exclude run of just --all-features flag
         --depth <NUM>                    Specify a max number of simultaneous feature flags of
                                          --feature-powerset
+        --random <NUM_SAMPLES>           Performs with random feature combinations up to the number
+                                         specified per crate
         --group-features <FEATURES>...   Space or comma separated list of features to group
         --mutually-exclusive-features <FEATURES>... Space or comma separated list of features to not use
                                          together


### PR DESCRIPTION
Originally proposed by @orlp. https://discord.com/channels/273534239310479360/273541522815713281/1263250421653438625

```
        --random <NUM_SAMPLES>
            Performs with random feature combinations up to the number specified per crate.

            This flag can only be used together with --feature-powerset flag.
```



There are a few things missing as I have just roughly implemented the idea:
-  [ ] Resolve todos in code comments:
      https://github.com/taiki-e/cargo-hack/blob/d6b31648b0ee18719ca7b15d0d998e1577a0d3fd/src/features.rs#L232-L236
- [ ] Add a seeding option (https://github.com/taiki-e/cargo-hack/pull/255#issuecomment-2940507876)

Example:
```console
$ cargo hack check --feature-powerset --no-dev-deps --optional-deps --random 10
info: --no-dev-deps modifies real `Cargo.toml` while cargo-hack is running and restores it when finished
info: running `cargo check --no-default-features --features b,c,default,member1` on real (1/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s

info: running `cargo check --no-default-features --features c,default` on real (2/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s

info: running `cargo check --no-default-features --features a,b,default,member1` on real (3/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s

info: running `cargo check --no-default-features --features c,default` on real (4/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s

info: running `cargo check --no-default-features --features default,member1` on real (5/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s

info: running `cargo check --no-default-features --features a,b` on real (6/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s

info: running `cargo check --no-default-features --features c` on real (7/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s

info: running `cargo check --no-default-features --features a,b,c,member1` on real (8/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s

info: running `cargo check --no-default-features --features a,c,default` on real (9/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s

info: running `cargo check --no-default-features --features a,b,default` on real (10/10)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
```