### PR TITLE
Allow using `--exclude` without also specifying `--workspace`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Allow using `--exclude` without also specifying `--workspace`. ([#258](https://github.com/taiki-e/cargo-hack/pull/258), thanks @xStrom)
+
 ## [0.6.32] - 2024-10-26
 
 - Disable quick-install fallback of cargo-binstall.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ OPTIONS:
         --exclude <SPEC>...
             Exclude packages from the check.
 
-            This flag can only be used together with --workspace
-
         --manifest-path <PATH>
             Path to Cargo.toml.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -380,11 +380,6 @@ impl Args {
 
         term::set_coloring(color.as_deref())?;
 
-        if !exclude.is_empty() && !workspace {
-            // TODO: This is the same behavior as cargo, but should we allow it to be used
-            // in the root of a virtual workspace as well?
-            requires("--exclude", &["--workspace"])?;
-        }
         if ignore_unknown_features {
             if features.is_empty() && include_features.is_empty() && group_features.is_empty() {
                 requires("--ignore-unknown-features", &[
@@ -682,9 +677,7 @@ const HELP: &[HelpText<'_>] = &[
     ("-p", "--package", "<SPEC>...", "Package(s) to check", &[]),
     ("", "--all", "", "Alias for --workspace", &[]),
     ("", "--workspace", "", "Perform command for all packages in the workspace", &[]),
-    ("", "--exclude", "<SPEC>...", "Exclude packages from the check", &[
-        "This flag can only be used together with --workspace",
-    ]),
+    ("", "--exclude", "<SPEC>...", "Exclude packages from the check", &[]),
     ("", "--manifest-path", "<PATH>", "Path to Cargo.toml", &[]),
     ("", "--locked", "", "Require Cargo.lock is up to date", &[]),
     ("-F", "--features", "<FEATURES>...", "Space or comma separated list of features to activate", &[]),

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -19,8 +19,6 @@ OPTIONS:
         --exclude <SPEC>...
             Exclude packages from the check.
 
-            This flag can only be used together with --workspace
-
         --manifest-path <PATH>
             Path to Cargo.toml.
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -288,6 +288,16 @@ fn exclude() {
         .stderr_not_contains("running `cargo check` on member1")
         .stderr_contains("running `cargo check` on member2");
 
+    cargo_hack(["check", "--package", "member1", "--package", "member2", "--exclude", "member1"])
+        .assert_success("virtual")
+        .stderr_not_contains("running `cargo check` on member1")
+        .stderr_contains("running `cargo check` on member2");
+
+    cargo_hack(["check", "--exclude", "member1"])
+        .assert_success("virtual")
+        .stderr_not_contains("running `cargo check` on member1")
+        .stderr_contains("running `cargo check` on member2");
+
     // not_found is warning
     cargo_hack(["check", "--all", "--exclude", "foo"]).assert_failure("virtual").stderr_contains(
         "
@@ -296,14 +306,6 @@ fn exclude() {
         running `cargo check` on member2
         ",
     );
-}
-
-#[test]
-fn exclude_failure() {
-    // not with --workspace
-    cargo_hack(["check", "--exclude", "member1"])
-        .assert_failure("virtual")
-        .stderr_contains("--exclude can only be used together with --workspace");
 }
 
 #[test]


### PR DESCRIPTION
We're using `cargo-hack` at [Linebender](https://linebender.org/), in ~15 repositories and growing. Thanks for your continued maintenance of this project!

In order for us to maintain CI scripts across that many repositories, we try to write them in a super generic way. So that we can mostly copy-paste the script and only have minimal configuration variables per repository.

For example, one set of variables we currently have for [Xilem](https://github.com/linebender/xilem) is:
```yml
# List of packages that will be checked with the minimum supported Rust version.
RUST_MIN_VER_PKGS: "-p xilem -p xilem_core -p masonry"
# List of packages that can not target Wasm.
NO_WASM_PKGS: "--exclude masonry --exclude xilem"
```

So for the MSRV job we reference `RUST_MIN_VER_PKGS` instead of `--workspace` and for the Wasm job we add `NO_WASM_PKGS`. Works well. However a complication arises with the MSRV Wasm job! Because the combination of `-p xilem -p xilem_core -p masonry --exclude masonry --exclude xilem` does not currently work with `cargo-hack`.

Our current solution is to just have a third variable:
```yml
# RUST_MIN_VER_PKGS - NO_WASM_PKGS, evaluated.
RUST_MIN_VER_WASM_PKGS: "-p xilem_core"
```

It works, of course. However it would be nice to not have to keep this additional variable in sync, especially across all our repositories.

This PR here addresses the problem at the `cargo-hack` level by removing the requirement to also specify `--workspace` when using `--exclude`. This works nicely and allows us to remove that extra variable and skip the work of maintaining it for each repository.