### PR TITLE
Add --workspace-behavior=cargo and improve --package/--exclude handling

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -1,5 +1,7 @@
 binstall
 objc
+pkgid
+pkgname
 qpmember
 subcrate
 vvpmember

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support versioned name and package spec in `--package` and `--exclude`.
+
+- Add `--workspace-behavior=cargo` option.
+
+  This is for use cases where cargo-hack's workspace handling does not work. Note that this is incompatible with flags that require cargo-hack's workspace handling to work properly (e.g., `--each-feature`, `--feature-powerset`, etc.).
+
+- Diagnostics improvements.
+
 ## [0.6.44] - 2026-03-20
 
 - Publish [artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations).

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ OPTIONS:
 
             If this option is not used, the environment will be automatically detected.
 
+        --workspace-behavior=cargo
+            Use Cargo's workspace handling.
+
+            This is for use cases where cargo-hack's workspace handling does not work.
+
+            Note that this is incompatible with flags that require cargo-hack's workspace handling
+            to work properly (e.g., `--each-feature`, `--feature-powerset`, etc.).
+
         --print-command-list
             Print commands without run (Unstable).
 
@@ -615,14 +623,12 @@ pkg install cargo-hack
 - [cargo-llvm-cov]: Cargo subcommand to easily use LLVM source-based code coverage.
 - [cargo-minimal-versions]: Cargo subcommand for proper use of `-Z minimal-versions`.
 - [cargo-config2]: Library to load and resolve Cargo configuration.
-- [cargo-no-dev-deps]: Cargo subcommand for running cargo without dev-dependencies. This is an extraction of the [`--no-dev-deps` flag of cargo-hack](#--no-dev-deps) to be used as a stand-alone cargo subcommand.
 
 [#15]: https://github.com/taiki-e/cargo-hack/issues/15
 [cargo-config2]: https://github.com/taiki-e/cargo-config2
 [cargo-llvm-cov]: https://github.com/taiki-e/cargo-llvm-cov
 [cargo-metadata]: https://doc.rust-lang.org/cargo/commands/cargo-metadata.html
 [cargo-minimal-versions]: https://github.com/taiki-e/cargo-minimal-versions
-[cargo-no-dev-deps]: https://github.com/taiki-e/cargo-no-dev-deps
 [cargo#3620]: https://github.com/rust-lang/cargo/issues/3620
 [cargo#4106]: https://github.com/rust-lang/cargo/issues/4106
 [cargo#4242]: https://github.com/rust-lang/cargo/issues/4242

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Result, bail, format_err};
 
-use crate::{ProcessBuilder, version::Version};
+use crate::{ProcessBuilder, metadata::Package, version::Version};
 
 pub(crate) fn version(mut cmd: ProcessBuilder<'_>) -> Result<Version> {
     // Use verbose version output because the packagers add extra strings to the normal version output.
@@ -20,4 +20,229 @@ pub(crate) fn version(mut cmd: ProcessBuilder<'_>) -> Result<Version> {
     }
 
     Ok(version)
+}
+
+// From cargo-llvm-cov
+// TODO: glob pattern
+pub(crate) fn match_pkg_spec(pkg: &Package, name_or_spec: &str) -> Result<bool> {
+    /*
+    Refs: https://doc.rust-lang.org/1.93.0/cargo/reference/pkgid-spec.html
+        spec := pkgname |
+            [ kind "+" ] proto "://" hostname-and-path [ "?" query] [ "#" ( pkgname | semver ) ]
+        query = ( "branch" | "tag" | "rev" ) "=" ref
+        pkgname := name [ ("@" | ":" ) semver ]
+        semver := digits [ "." digits [ "." digits [ "-" prerelease ] [ "+" build ]]]
+
+        kind = "registry" | "git" | "path"
+        proto := "http" | "git" | "file" | ...
+    */
+    fn split_spec(s: &str) -> Option<(&str, &str, Option<&str>, Option<&str>)> {
+        let (proto_etc, hostname_and_path_etc) = s.split_once("://")?;
+        let proto = proto_etc.split_once('+').unwrap_or(("", proto_etc)).1; // drop kind
+        let (hostname_and_path_etc, pkgname_or_semver) =
+            hostname_and_path_etc.split_once('#').unwrap_or((hostname_and_path_etc, ""));
+        let (hostname_and_path, query) =
+            hostname_and_path_etc.split_once('?').unwrap_or((hostname_and_path_etc, ""));
+        Some((
+            proto,
+            hostname_and_path,
+            if query.is_empty() { None } else { Some(query) },
+            if pkgname_or_semver.is_empty() { None } else { Some(pkgname_or_semver) },
+        ))
+    }
+    fn split_semver(
+        s: &str,
+    ) -> Option<(&str, Option<(&str, Option<(&str, Option<&str>, Option<&str>)>)>)> {
+        let mut digits = s.splitn(3, '.');
+        let major = digits.next()?;
+        let Some(minor) = digits.next() else {
+            return Some((major, None));
+        };
+        let Some(patch_etc) = digits.next() else {
+            return Some((major, Some((minor, None))));
+        };
+        let (patch_etc, meta) = patch_etc.split_once('+').unwrap_or((patch_etc, ""));
+        let (patch, pre) = patch_etc.split_once('-').unwrap_or((patch_etc, ""));
+        Some((
+            major,
+            Some((
+                minor,
+                Some((
+                    patch,
+                    if pre.is_empty() { None } else { Some(pre) },
+                    if meta.is_empty() { None } else { Some(meta) },
+                )),
+            )),
+        ))
+    }
+    let name = &*pkg.name;
+    let p = name_or_spec;
+    let (version, full_version) = if p.starts_with(name) {
+        if p.len() == name.len() {
+            return Ok(true); // version omitted
+        }
+        if !matches!(p.as_bytes().get(name.len()), Some(&b'@' | &b':')) {
+            return Ok(false); // pkgname unmatched
+        }
+        (&p[name.len() + 1..], &*pkg.version)
+    } else {
+        let p = p.trim_ascii_end(); // pkgid may contains trailing newline (e.g., when pkgid is got from `cargo pkgid -p <package>`)
+        let full = &*pkg.id;
+        let Some((proto, hostname_and_path, query, pkgname_or_semver)) = split_spec(p) else {
+            return Ok(false); // p is not pkg spec
+        };
+        let Some((full_proto, full_hostname_and_path, full_query, full_pkgname_or_semver)) =
+            split_spec(full)
+        else {
+            bail!("invalid pkg spec ({full}) from cargo-metadata")
+        };
+        if proto != full_proto || hostname_and_path != full_hostname_and_path {
+            return Ok(false); // proto or hostname-and-path unmatched
+        }
+        if query.is_some() && query != full_query {
+            return Ok(false); // query unmatched
+        }
+        let Some(pkgname_or_semver) = pkgname_or_semver else {
+            return Ok(true); // pkgname | semver omitted
+        };
+        let Some(full_pkgname_or_semver) = full_pkgname_or_semver else {
+            return Ok(false); // extra pkgname | semver
+        };
+        match (
+            pkgname_or_semver.split_once(['@', ':']),
+            full_pkgname_or_semver.split_once(['@', ':']),
+        ) {
+            (Some((pkgname, semver)), Some((full_pkgname, full_semver))) => {
+                if pkgname != full_pkgname {
+                    return Ok(false); // pkgname unmatched
+                }
+                (semver, full_semver)
+            }
+            (Some(_), None) => return Ok(false), // extra semver
+            (None, _) => return Ok(true),        // pkgname omitted or no pkgname in spec
+        }
+    };
+    let Some((major, minor_etc)) = split_semver(version) else {
+        warn!("invalid pkg version ({version}) from --package");
+        return Ok(false); // invalid version
+    };
+    let Some((full_major, Some((full_minor, Some((full_patch, full_pre, full_meta)))))) =
+        split_semver(full_version)
+    else {
+        bail!("invalid pkg version ({full_version}) from cargo-metadata")
+    };
+    if major != full_major {
+        return Ok(false); // major unmatched
+    }
+    let Some((minor, patch_etc)) = minor_etc else {
+        return Ok(true); // minor version omitted
+    };
+    if minor != full_minor {
+        return Ok(false); // minor unmatched
+    }
+    let Some((patch, pre, meta)) = patch_etc else {
+        return Ok(true); // patch version omitted
+    };
+    if patch != full_patch
+        || pre.is_some() && pre != full_pre
+        || meta.is_some() && meta != full_meta
+    {
+        return Ok(false); // patch or pre or meta unmatched
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::Path};
+
+    use super::{Package, match_pkg_spec};
+
+    #[test]
+    fn test_match_pkg_spec() {
+        // Examples are from https://doc.rust-lang.org/1.93.0/cargo/reference/pkgid-spec.html#example-specifications
+
+        let new_pkg = |id: &str, name: &str, version: &str| Package {
+            id: id.into(),
+            name: name.into(),
+            version: version.into(),
+            dependencies: Box::default(),
+            features: BTreeMap::new(),
+            manifest_path: Path::new("").into(),
+            publish: true,
+            rust_version: None,
+        };
+
+        // crates.io
+        let pkg = &new_pkg(
+            "registry+https://github.com/rust-lang/crates.io-index#regex@1.4.3",
+            "regex",
+            "1.4.3",
+        );
+        // name
+        assert!(match_pkg_spec(pkg, "regex").unwrap());
+        assert!(!match_pkg_spec(pkg, "regex-syntax").unwrap());
+        // name+version
+        assert!(match_pkg_spec(pkg, "regex@1").unwrap());
+        assert!(match_pkg_spec(pkg, "regex@1.4").unwrap());
+        assert!(match_pkg_spec(pkg, "regex@1.4.3").unwrap());
+        assert!(match_pkg_spec(pkg, "regex:1.4").unwrap());
+        assert!(!match_pkg_spec(pkg, "regex@2").unwrap());
+        assert!(!match_pkg_spec(pkg, "regex@1.5").unwrap());
+        assert!(!match_pkg_spec(pkg, "regex@1.4.2").unwrap());
+        assert!(!match_pkg_spec(pkg, "regex@1.4.4").unwrap());
+        // spec
+        assert!(match_pkg_spec(pkg, "https://github.com/rust-lang/crates.io-index#regex").unwrap());
+        assert!(
+            match_pkg_spec(pkg, "https://github.com/rust-lang/crates.io-index#regex@1.4.3")
+                .unwrap()
+        );
+        assert!(
+            match_pkg_spec(pkg, "https://github.com/rust-lang/crates.io-index#regex@1.4").unwrap()
+        );
+        assert!(
+            match_pkg_spec(
+                pkg,
+                "registry+https://github.com/rust-lang/crates.io-index#regex@1.4.3"
+            )
+            .unwrap()
+        );
+
+        // git
+        let pkg = &new_pkg(
+            "git+ssh://git@github.com/rust-lang/regex.git?branch=dev#regex@1.4.3",
+            "regex",
+            "1.4.3",
+        );
+        assert!(match_pkg_spec(pkg, "regex").unwrap());
+        assert!(
+            match_pkg_spec(pkg, "ssh://git@github.com/rust-lang/regex.git#regex@1.4.3").unwrap()
+        );
+        assert!(
+            match_pkg_spec(pkg, "git+ssh://git@github.com/rust-lang/regex.git#regex@1.4.3")
+                .unwrap()
+        );
+        assert!(
+            match_pkg_spec(
+                pkg,
+                "git+ssh://git@github.com/rust-lang/regex.git?branch=dev#regex@1.4.3"
+            )
+            .unwrap()
+        );
+        let pkg = &new_pkg("git+https://github.com/rust-lang/cargo#0.52.0", "cargo", "0.52.0");
+        assert!(match_pkg_spec(pkg, "https://github.com/rust-lang/cargo#0.52.0").unwrap());
+        assert!(match_pkg_spec(pkg, "git+https://github.com/rust-lang/cargo#0.52.0").unwrap());
+        assert!(
+            !match_pkg_spec(pkg, "https://github.com/rust-lang/cargo#cargo-platform@0.1.2")
+                .unwrap()
+        );
+
+        // local
+        let pkg = &new_pkg("path+file:///path/to/my/project/foo#1.1.8", "foo", "1.1.8");
+        assert!(match_pkg_spec(pkg, "foo").unwrap());
+        assert!(match_pkg_spec(pkg, "file:///path/to/my/project/foo").unwrap());
+        assert!(match_pkg_spec(pkg, "file:///path/to/my/project/foo#1.1.8").unwrap());
+        assert!(match_pkg_spec(pkg, "path+file:///path/to/my/project/foo#1.1").unwrap());
+        assert!(match_pkg_spec(pkg, "path+file:///path/to/my/project/foo#1.1.8").unwrap());
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,10 @@ pub(crate) struct Args {
     pub(crate) package: Vec<String>,
     /// --exclude <SPEC>...
     pub(crate) exclude: Vec<String>,
-    /// --workspace, (--all)
+    /// --workspace / --all
     pub(crate) workspace: bool,
+    /// --all
+    pub(crate) all: bool,
     /// --each-feature
     pub(crate) each_feature: bool,
     /// --feature-powerset
@@ -63,6 +65,8 @@ pub(crate) struct Args {
     pub(crate) version_step: u16,
     /// --log-group
     pub(crate) log_group: LogGroup,
+    /// --workspace-behavior=cargo
+    pub(crate) workspace_behavior: WorkspaceBehavior,
 
     // options for --each-feature and --feature-powerset
     /// --optional-deps [DEPS]...
@@ -101,6 +105,12 @@ pub(crate) struct Args {
     // propagated to cargo (as a part of leading_args)
     /// --no-default-features
     pub(crate) no_default_features: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum WorkspaceBehavior {
+    Cargo,
+    Default,
 }
 
 impl Args {
@@ -148,6 +158,7 @@ impl Args {
         let mut features = vec![];
 
         let mut workspace = false;
+        let mut all = false;
         let mut no_dev_deps = false;
         let mut remove_dev_deps = false;
         let mut each_feature = false;
@@ -167,6 +178,7 @@ impl Args {
         let mut version_step = None;
         let mut log_group: Option<String> = None;
         let mut disable_log_grouping = false;
+        let mut workspace_behavior: Option<String> = None;
 
         let mut optional_deps = None;
         let mut include_features = vec![];
@@ -257,6 +269,7 @@ impl Args {
                 Long("version-range") => parse_opt!(version_range, false),
                 Long("version-step") => parse_opt!(version_step, false),
                 Long("log-group") => parse_opt!(log_group, false),
+                Long("workspace-behavior") => parse_opt!(workspace_behavior, false),
 
                 Short('p') | Long("package") => package.push(parser.value()?.parse()?),
                 Long("exclude") => exclude.push(parser.value()?.parse()?),
@@ -298,7 +311,11 @@ impl Args {
                     }
                 }
 
-                Long("workspace" | "all") => parse_flag!(workspace),
+                Long("workspace") => parse_flag!(workspace),
+                Long("all") => {
+                    all = true;
+                    parse_flag!(workspace);
+                }
                 Long("no-dev-deps") => parse_flag!(no_dev_deps),
                 Long("remove-dev-deps") => parse_flag!(remove_dev_deps),
                 Long("each-feature") => parse_flag!(each_feature),
@@ -458,6 +475,21 @@ impl Args {
                 _ => {}
             }
         }
+        let workspace_behavior = match workspace_behavior.as_deref() {
+            Some("cargo") => {
+                if each_feature {
+                    conflicts("--workspace-behavior=cargo", "--each-feature")?;
+                }
+                if feature_powerset {
+                    conflicts("--workspace-behavior=cargo", "--feature-powerset")?;
+                }
+                WorkspaceBehavior::Cargo
+            }
+            Some(other) => {
+                bail!("argument for --workspace-behavior must be cargo, but found `{other}`")
+            }
+            None => WorkspaceBehavior::Default,
+        };
 
         if let Some(pos) = cargo_args.iter().position(|a| match &**a {
             "--example" | "--examples" | "--test" | "--tests" | "--bench" | "--benches"
@@ -613,6 +645,7 @@ impl Args {
             package,
             exclude,
             workspace,
+            all,
             each_feature,
             feature_powerset,
             no_dev_deps,
@@ -633,6 +666,7 @@ impl Args {
             version_range,
             version_step,
             log_group,
+            workspace_behavior,
 
             depth,
             group_features,
@@ -846,6 +880,10 @@ const HELP: &[HelpText<'_>] = &[
     ]),
     ("", "--log-group", "<KIND>", "Log grouping: none, github-actions", &[
         "If this option is not used, the environment will be automatically detected.",
+    ]),
+    ("", "--workspace-behavior=cargo", "", "Use Cargo's workspace handling", &[
+        "This is for use cases where cargo-hack's workspace handling does not work.",
+        "Note that this is incompatible with flags that require cargo-hack's workspace handling to work properly (e.g., `--each-feature`, `--feature-powerset`, etc.).",
     ]),
     ("", "--print-command-list", "", "Print commands without run (Unstable)", &[]),
     ("", "--no-manifest-path", "", "Do not pass --manifest-path option to cargo (Unstable)", &[]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ use std::{
 use anyhow::{Error, Result, bail, format_err};
 
 use crate::{
+    cargo::match_pkg_spec,
+    cli::WorkspaceBehavior,
     context::Context,
     features::Feature,
     metadata::PackageId,
@@ -68,16 +70,31 @@ fn try_main() -> Result<()> {
         if let Some(range) = cx.version_range {
             let mut versions = BTreeMap::new();
             let steps = rustup::version_range(range, cx.version_step, &packages, cx)?;
+            let mut workspace_msrv = None;
             for pkg in packages {
                 let msrv = cx
                     .rust_version(pkg.id)
                     .map(str::parse::<Version>)
                     .transpose()?
                     .map(Version::strip_patch);
+                match cx.workspace_behavior {
+                    WorkspaceBehavior::Default => {}
+                    WorkspaceBehavior::Cargo => {
+                        if let Some(workspace_msrv) = workspace_msrv {
+                            if msrv != workspace_msrv {
+                                bail!(
+                                    "currently only single MSRV is supported by --workspace-behavior=cargo; consider using --package or --exclude to run per MSRV"
+                                )
+                            }
+                        } else {
+                            workspace_msrv = Some(msrv);
+                        }
+                    }
+                }
                 if range == VersionRange::msrv() {
                     let msrv = msrv.ok_or_else(|| {
                         format_err!(
-                            "no rust-version field in {}'s Cargo.toml is specified",
+                            "no rust-version field in {0}'s Cargo.toml is specified; consider setting rust-version field or excluding {0}",
                             cx.packages(pkg.id).name
                         )
                     })?;
@@ -117,11 +134,22 @@ fn try_main() -> Result<()> {
             }
 
             for (cargo_version, packages) in &versions {
-                for package in packages {
-                    if cx.target.is_empty() || cargo_version.minor >= 64 {
-                        progress.total += package.feature_count;
-                    } else {
-                        progress.total += package.feature_count * cx.target.len();
+                match cx.workspace_behavior {
+                    WorkspaceBehavior::Default => {
+                        for package in packages {
+                            if cx.target.is_empty() || cargo_version.minor >= 64 {
+                                progress.total += package.feature_count;
+                            } else {
+                                progress.total += package.feature_count * cx.target.len();
+                            }
+                        }
+                    }
+                    WorkspaceBehavior::Cargo => {
+                        if cx.target.is_empty() || cargo_version.minor >= 64 {
+                            progress.total += 1;
+                        } else {
+                            progress.total += cx.target.len();
+                        }
                     }
                 }
             }
@@ -149,8 +177,15 @@ fn try_main() -> Result<()> {
                 )?;
             }
         } else {
-            let total = packages.iter().map(|p| p.feature_count).sum();
-            progress.total = total;
+            match cx.workspace_behavior {
+                WorkspaceBehavior::Default => {
+                    let total = packages.iter().map(|p| p.feature_count).sum();
+                    progress.total = total;
+                }
+                WorkspaceBehavior::Cargo => {
+                    progress.total = 1;
+                }
+            }
             default_cargo_exec_on_packages(cx, &packages, &mut progress, &mut keep_going)?;
         }
         if keep_going.count > 0 {
@@ -328,7 +363,8 @@ struct PackageRuns<'a> {
 
 fn determine_package_list(cx: &Context) -> Result<Vec<PackageRuns<'_>>> {
     for spec in &cx.exclude {
-        if !cx.workspace_members().any(|&id| *cx.packages(id).name == **spec) {
+        if !cx.workspace_members().any(|&id| match_pkg_spec(cx.packages(id), spec).unwrap_or(false))
+        {
             warn!(
                 "excluded package(s) `{spec}` not found in workspace `{}`",
                 cx.workspace_root().display()
@@ -338,30 +374,36 @@ fn determine_package_list(cx: &Context) -> Result<Vec<PackageRuns<'_>>> {
     Ok(if cx.workspace {
         let ids: Vec<_> = cx
             .workspace_members()
-            .filter(|&&id| !cx.exclude.iter().any(|e| *cx.packages(id).name == **e))
+            .filter(|&&id| {
+                !cx.exclude.iter().any(|e| match_pkg_spec(cx.packages(id), e).unwrap_or(false))
+            })
             .collect();
         let multiple_packages = ids.len() > 1;
         ids.iter().filter_map(|&&id| determine_kind(cx, id, multiple_packages)).collect()
     } else if !cx.package.is_empty() {
-        if let Some(spec) = cx
-            .package
-            .iter()
-            .find(|&spec| !cx.workspace_members().any(|&id| *cx.packages(id).name == **spec))
-        {
+        if let Some(spec) = cx.package.iter().find(|p| {
+            !cx.workspace_members().any(|&id| match_pkg_spec(cx.packages(id), p).unwrap_or(false))
+        }) {
             bail!("package ID specification `{spec}` matched no packages")
         }
 
         let ids: Vec<_> = cx
             .workspace_members()
-            .filter(|&&id| cx.package.iter().any(|p| *cx.packages(id).name == **p))
-            .filter(|&&id| !cx.exclude.iter().any(|e| *cx.packages(id).name == **e))
+            .filter(|&&id| {
+                cx.package.iter().any(|p| match_pkg_spec(cx.packages(id), p).unwrap_or(false))
+            })
+            .filter(|&&id| {
+                !cx.exclude.iter().any(|e| match_pkg_spec(cx.packages(id), e).unwrap_or(false))
+            })
             .collect();
         let multiple_packages = ids.len() > 1;
         ids.iter().filter_map(|&&id| determine_kind(cx, id, multiple_packages)).collect()
     } else if cx.current_package().is_none() {
         let ids: Vec<_> = cx
             .workspace_members()
-            .filter(|&&id| !cx.exclude.iter().any(|e| *cx.packages(id).name == **e))
+            .filter(|&&id| {
+                !cx.exclude.iter().any(|e| match_pkg_spec(cx.packages(id), e).unwrap_or(false))
+            })
             .collect();
         let multiple_packages = ids.len() > 1;
         ids.iter().filter_map(|&&id| determine_kind(cx, id, multiple_packages)).collect()
@@ -370,7 +412,9 @@ fn determine_package_list(cx: &Context) -> Result<Vec<PackageRuns<'_>>> {
         let multiple_packages = false;
         cx.workspace_members()
             .find(|&&id| cx.packages(id).name == *current_package)
-            .filter(|&&id| !cx.exclude.iter().any(|e| *cx.packages(id).name == **e))
+            .filter(|&&id| {
+                !cx.exclude.iter().any(|e| match_pkg_spec(cx.packages(id), e).unwrap_or(false))
+            })
             .and_then(|&id| determine_kind(cx, id, multiple_packages).map(|p| vec![p]))
             .unwrap_or_default()
     })
@@ -450,23 +494,52 @@ fn exec_on_packages(
     if cx.locked {
         line.arg("--locked");
     }
+    match cx.workspace_behavior {
+        WorkspaceBehavior::Default => {}
+        WorkspaceBehavior::Cargo => {
+            if let Some(manifest_path) = &cx.manifest_path {
+                line.arg("--manifest-path");
+                line.arg(manifest_path);
+            }
+            for pkg in &cx.package {
+                line.arg("--package");
+                line.arg(pkg);
+            }
+            for pkg in &cx.exclude {
+                line.arg("--exclude");
+                line.arg(pkg);
+            }
+            if cx.all {
+                line.arg("--all");
+            } else if cx.workspace {
+                line.arg("--workspace");
+            }
+            line.append_features_from_args(cx, None);
+        }
+    }
     if cx.target.is_empty() || cargo_version >= 64 {
         // TODO: We should test that cargo's multi-target build does not break the resolver behavior required for a correct check.
         for target in &cx.target {
             line.arg("--target");
             line.arg(target);
         }
-        packages
-            .iter()
-            .try_for_each(|pkg| exec_on_package(cx, pkg.id, &pkg.kind, &line, progress, keep_going))
+        match cx.workspace_behavior {
+            WorkspaceBehavior::Default => packages.iter().try_for_each(|pkg| {
+                exec_on_package(cx, pkg.id, &pkg.kind, &line, progress, keep_going)
+            }),
+            WorkspaceBehavior::Cargo => exec_cargo(cx, None, &line, progress, keep_going),
+        }
     } else {
         cx.target.iter().try_for_each(|target| {
             let mut line = line.clone();
             line.arg("--target");
             line.arg(target);
-            packages.iter().try_for_each(|pkg| {
-                exec_on_package(cx, pkg.id, &pkg.kind, &line, progress, keep_going)
-            })
+            match cx.workspace_behavior {
+                WorkspaceBehavior::Default => packages.iter().try_for_each(|pkg| {
+                    exec_on_package(cx, pkg.id, &pkg.kind, &line, progress, keep_going)
+                }),
+                WorkspaceBehavior::Cargo => exec_cargo(cx, None, &line, progress, keep_going),
+            }
         })
     }
 }
@@ -482,7 +555,7 @@ fn exec_on_package(
     let package = cx.packages(id);
 
     let mut line = line.clone();
-    line.append_features_from_args(cx, id);
+    line.append_features_from_args(cx, Some(id));
 
     if !cx.no_manifest_path {
         line.arg("--manifest-path");
@@ -494,7 +567,7 @@ fn exec_on_package(
     match kind {
         Kind::Normal => {
             // only run with default features
-            return exec_cargo(cx, id, &line, progress, keep_going);
+            return exec_cargo(cx, Some(id), &line, progress, keep_going);
         }
         Kind::Each { .. } | Kind::Powerset { .. } => {}
     }
@@ -524,7 +597,7 @@ fn exec_on_package(
         // run with all features
         // https://github.com/taiki-e/cargo-hack/issues/42
         line.arg("--all-features");
-        exec_cargo(cx, id, &line, progress, keep_going)?;
+        exec_cargo(cx, Some(id), &line, progress, keep_going)?;
     }
 
     if !cx.no_default_features {
@@ -538,7 +611,7 @@ fn exec_on_package(
 
     if !cx.exclude_no_default_features {
         // run with no default features if the package has other features
-        exec_cargo(cx, id, &line, progress, keep_going)?;
+        exec_cargo(cx, Some(id), &line, progress, keep_going)?;
     }
 
     match kind {
@@ -581,7 +654,7 @@ fn exec_cargo_with_features(
 ) -> Result<()> {
     let mut line = line.clone();
     line.append_features(features);
-    exec_cargo(cx, id, &line, progress, keep_going)
+    exec_cargo(cx, Some(id), &line, progress, keep_going)
 }
 
 #[derive(Default)]
@@ -668,7 +741,7 @@ impl FromStr for Partition {
 
 fn exec_cargo(
     cx: &Context,
-    id: PackageId,
+    id: Option<PackageId>,
     line: &ProcessBuilder<'_>,
     progress: &mut Progress,
     keep_going: &mut KeepGoing,
@@ -678,7 +751,7 @@ fn exec_cargo(
         if let Err(e) = res {
             error!("{e:#}");
             keep_going.count = keep_going.count.saturating_add(1);
-            let name = &*cx.packages(id).name;
+            let name = if let Some(id) = id { &*cx.packages(id).name } else { "" };
             if !keep_going.failed_commands.contains_key(name) {
                 keep_going.failed_commands.insert(name.to_owned(), vec![]);
             }
@@ -692,7 +765,7 @@ fn exec_cargo(
 
 fn exec_cargo_inner(
     cx: &Context,
-    id: PackageId,
+    id: Option<PackageId>,
     line: &ProcessBuilder<'_>,
     progress: &mut Progress,
 ) -> Result<()> {
@@ -708,7 +781,7 @@ fn exec_cargo_inner(
     }
 
     if cx.clean_per_run {
-        cargo_clean(cx, Some(id))?;
+        cargo_clean(cx, id)?;
     }
 
     if cx.print_command_list {
@@ -754,17 +827,18 @@ fn print_command(mut line: ProcessBuilder<'_>) {
 
 fn log_and_update_progress(
     cx: &Context,
-    id: PackageId,
+    id: Option<PackageId>,
     line: &ProcessBuilder<'_>,
     progress: &mut Progress,
     action: &str,
 ) -> Option<LogGroupGuard> {
     // running/skipping `<command>` (on <package>) (<count>/<total>)
     let mut msg = String::new();
-    if term::verbose() {
+    if term::verbose() || id.is_none() {
         write!(msg, "{action} {line}").unwrap();
     } else {
-        write!(msg, "{action} {line} on {}", cx.packages(id).name).unwrap();
+        #[allow(clippy::unnecessary_unwrap)]
+        write!(msg, "{action} {line} on {}", cx.packages(id.unwrap()).name).unwrap();
     }
     progress.count += 1;
     write!(msg, " ({}/{})", progress.count, progress.total).unwrap();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -137,7 +137,8 @@ pub(crate) fn with(cx: &Context, f: impl FnOnce() -> Result<()>) -> Result<()> {
                 fs::write(manifest_path, doc.to_string())?;
             }
         }
-        if no_private && (no_dev_deps && root_id.is_some() || !private_crates.is_empty()) {
+        let has_root_crate = root_id.is_some();
+        if no_private && (no_dev_deps && has_root_crate || !private_crates.is_empty()) {
             let manifest_path = root_manifest;
             let (mut doc, orig) = match root_id {
                 Some(id) => {
@@ -157,7 +158,7 @@ pub(crate) fn with(cx: &Context, f: impl FnOnce() -> Result<()>) -> Result<()> {
                     )
                 }
             };
-            if no_dev_deps && root_id.is_some() {
+            if no_dev_deps && has_root_crate {
                 if term::verbose() {
                     info!("removing dev-dependencies from {}", manifest_path.display());
                 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -151,8 +151,8 @@ impl Metadata {
         let mut packages = Vec::with_capacity(raw_packages.len());
         let mut pkg_id_map = HashMap::with_capacity(raw_packages.len());
         for (i, pkg) in raw_packages.into_iter().enumerate() {
-            let (id, pkg) = Package::from_value(pkg, cargo_version)?;
-            pkg_id_map.insert(id, i);
+            let pkg = Package::from_value(pkg, cargo_version)?;
+            pkg_id_map.insert(pkg.id.clone(), i);
             packages.push(pkg);
         }
         let workspace_members = map
@@ -297,10 +297,11 @@ impl DepKindInfo {
 }
 
 pub(crate) struct Package {
+    pub(crate) id: String,
     /// The name of the package.
     pub(crate) name: Box<str>,
-    // /// The version of the package.
-    // pub(crate) version: Box<str>,
+    /// The version of the package.
+    pub(crate) version: Box<str>,
     /// List of dependencies of this particular package.
     pub(crate) dependencies: Box<[Dependency]>,
     /// Features provided by the crate, mapped to the features required by that feature.
@@ -318,13 +319,13 @@ pub(crate) struct Package {
 }
 
 impl Package {
-    fn from_value(mut value: Value, cargo_version: u32) -> ParseResult<(String, Self)> {
+    fn from_value(mut value: Value, cargo_version: u32) -> ParseResult<Self> {
         let map = value.as_object_mut().ok_or("packages")?;
 
-        let id = map.remove_string("id")?;
-        Ok((id, Self {
+        Ok(Self {
+            id: map.remove_string("id")?,
             name: map.remove_string("name")?,
-            // version: map.remove_string("version")?,
+            version: map.remove_string("version")?,
             dependencies: map
                 .remove_array("dependencies")?
                 .into_iter()
@@ -356,7 +357,7 @@ impl Package {
             } else {
                 None
             },
-        }))
+        })
     }
 
     pub(crate) fn optional_deps(&self) -> impl Iterator<Item = &str> + '_ {

--- a/src/process.rs
+++ b/src/process.rs
@@ -97,15 +97,19 @@ impl<'a> ProcessBuilder<'a> {
         }
     }
 
-    pub(crate) fn append_features_from_args(&mut self, cx: &Context, id: PackageId) {
+    pub(crate) fn append_features_from_args(&mut self, cx: &Context, id: Option<PackageId>) {
         if cx.ignore_unknown_features {
             self.append_features(cx.features.iter().filter(|&f| {
-                if cx.pkg_features(id).contains(f) {
-                    true
+                if let Some(id) = id {
+                    if cx.pkg_features(id).contains(f) {
+                        true
+                    } else {
+                        // ignored
+                        info!("skipped applying unknown `{f}` feature to {}", cx.packages(id).name);
+                        false
+                    }
                 } else {
-                    // ignored
-                    info!("skipped applying unknown `{f}` feature to {}", cx.packages(id).name);
-                    false
+                    true
                 }
             }));
         } else if !cx.features.is_empty() {

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -153,7 +153,7 @@ fn replace_command(lines: &str) -> String {
     if lines.contains("rustup run") {
         lines.to_owned()
     } else if let Some(minor) = *TEST_VERSION {
-        lines.replace("cargo ", &format!("rustup run 1.{minor} cargo "))
+        lines.replace("`cargo ", &format!("`rustup run 1.{minor} cargo "))
     } else {
         lines.to_owned()
     }

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -200,6 +200,14 @@ OPTIONS:
 
             If this option is not used, the environment will be automatically detected.
 
+        --workspace-behavior=cargo
+            Use Cargo's workspace handling.
+
+            This is for use cases where cargo-hack's workspace handling does not work.
+
+            Note that this is incompatible with flags that require cargo-hack's workspace handling
+            to work properly (e.g., `--each-feature`, `--feature-powerset`, etc.).
+
         --print-command-list
             Print commands without run (Unstable).
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -50,6 +50,7 @@ OPTIONS:
         --partition <M/N>                Partition runs and execute only its subset according to
                                          M/N
         --log-group <KIND>               Log grouping: none, github-actions
+        --workspace-behavior=cargo       Use Cargo's workspace handling
         --print-command-list             Print commands without run (Unstable)
         --no-manifest-path               Do not pass --manifest-path option to cargo (Unstable)
     -v, --verbose                        Use verbose output

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -78,12 +78,12 @@ fn real_manifest() {
         .assert_success("real")
         .stderr_not_contains(
             "
-            running `cargo check` on member1
-            running `cargo check` on member2
-            running `cargo check` on member3
+            member1
+            member2
+            member3
             ",
         )
-        .stderr_contains("running `cargo check` on real");
+        .stderr_contains("running `cargo check` on real (1/1)");
 
     cargo_hack(["check", "--workspace"]).assert_success("real").stderr_contains(
         "
@@ -93,6 +93,13 @@ fn real_manifest() {
         running `cargo check` on real (4/4)
         ",
     );
+    cargo_hack(["check", "--all", "--workspace-behavior=cargo"])
+        .assert_success("real")
+        .stderr_contains(
+            "
+            running `cargo check --all` (1/1)
+            ",
+        );
 }
 
 #[test]
@@ -101,6 +108,7 @@ fn virtual_manifest() {
         "
         running `cargo check` on member1 (1/3)
         running `cargo check` on member2 (2/3)
+        running `cargo check` on not_find_manifest (3/3)
         ",
     );
 
@@ -108,8 +116,17 @@ fn virtual_manifest() {
         "
         running `cargo check` on member1 (1/3)
         running `cargo check` on member2 (2/3)
+        running `cargo check` on not_find_manifest (3/3)
         ",
     );
+
+    cargo_hack(["check", "--all", "--workspace-behavior=cargo"])
+        .assert_success("virtual")
+        .stderr_contains(
+            "
+            running `cargo check --all` (1/1)
+            ",
+        );
 }
 
 #[test]
@@ -508,6 +525,10 @@ fn each_feature_failure() {
     cargo_hack(["check", "--each-feature", "--no-default-features"])
         .assert_failure("real")
         .stderr_contains("--no-default-features may not be used together with --each-feature");
+
+    cargo_hack(["check", "--each-feature", "--workspace-behavior=cargo"])
+        .assert_failure("real")
+        .stderr_contains("--workspace-behavior=cargo may not be used together with --each-feature");
 }
 
 #[test]
@@ -566,6 +587,12 @@ fn feature_powerset_failure() {
     cargo_hack(["check", "--feature-powerset", "--no-default-features"])
         .assert_failure("real")
         .stderr_contains("--no-default-features may not be used together with --feature-powerset");
+
+    cargo_hack(["check", "--feature-powerset", "--workspace-behavior=cargo"])
+        .assert_failure("real")
+        .stderr_contains(
+            "--workspace-behavior=cargo may not be used together with --feature-powerset",
+        );
 }
 
 #[test]


### PR DESCRIPTION
Changes:

- Support versioned name and package spec in `--package` and `--exclude`.

- Add `--workspace-behavior=cargo` option.

  This is for use cases where cargo-hack's  workspace handling does not work. Note that this is incompatible with flags that require cargo-hack's workspace handling to work properly (e.g., `--each-feature`, `--feature-powerset`, etc.).

- Diagnostics improvements.

Closes https://github.com/taiki-e/cargo-hack/issues/297