### PR TITLE
Fix empty tail partitions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,12 @@ struct Progress {
 
 impl Progress {
     fn in_partition(&self, partition: &Partition) -> bool {
-        let current_index = self.count / self.total.div_ceil(partition.count);
+        // Spread runs over near-even buckets without overfilling early partitions.
+        let current_index = if self.total <= partition.count {
+            self.count
+        } else {
+            self.count * partition.count / self.total
+        };
         current_index == partition.index
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2012,13 +2012,17 @@ fn partition() {
             ",
         );
 
-    cargo_hack(["check", "--feature-powerset", "--partition", "5/5"])
+    cargo_hack(["check", "--feature-powerset", "--partition", "5/5", "--print-command-list"])
         .assert_success("powerset_deduplication")
+        .stdout_contains(
+            "
+            cargo check --manifest-path Cargo.toml --no-default-features --features e
+            cargo check --manifest-path Cargo.toml --no-default-features --features c,e
+            ",
+        )
         .stderr_contains(
             "
             skipping `cargo check --no-default-features --features c,d` on deduplication (9/11)
-            running `cargo check --no-default-features --features e` on deduplication (10/11)
-            running `cargo check --no-default-features --features c,e` on deduplication (11/11)
             ",
         );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2011,6 +2011,16 @@ fn partition() {
             running `cargo check --no-default-features --features a,b,c,default` on real (17/17)
             ",
         );
+
+    cargo_hack(["check", "--feature-powerset", "--partition", "5/5"])
+        .assert_success("powerset_deduplication")
+        .stderr_contains(
+            "
+            skipping `cargo check --no-default-features --features c,d` on deduplication (9/11)
+            running `cargo check --no-default-features --features e` on deduplication (10/11)
+            running `cargo check --no-default-features --features c,e` on deduplication (11/11)
+            ",
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fix `--partition` bucket selection so later partitions do not go empty when earlier buckets round up.
- Add a regression covering the 11-run `--feature-powerset --partition 5/5` case from #287.

## Why

Fixes #287. With 11 generated runs and 5 partitions, the old `ceil(total / partitions)` bucket size assigned the first 9 runs to partitions 1-3, the final 2 runs to partition 4, and left partition 5 empty.

## Validation

- `/root/oss/cargo-hack/target/debug/cargo-hack hack check --feature-powerset --partition 5/5 --print-command-list` from `tests/fixtures/powerset_deduplication` — printed the final two commands for partition 5 after the fix
- `cargo test partition --test test -- --nocapture` — passed
- `cargo test --bin cargo-hack` — passed
- `cargo test --test test -- --skip multi_target --skip rust_version --skip version_range --skip version_range_failure` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo +nightly fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo test` — did not complete locally because this host is out of disk while rustup downloads old toolchains for the rustup-dependent version/target tests